### PR TITLE
v0.28 sub-PR 2: Controller.java updates

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
@@ -170,7 +170,7 @@ public class Controller {
                         request.getName(),
                         request.getIssuerId(),
                         fromAPI(request.getDenomination()),
-                        fromAPI(request.getAssetIdentifier())
+                        null // assetIdentifier removed in 0.28
                 ),
                 cid -> new PendingAssetCreation(cid, new OperationMetadata(new PollingResponseStrategy()))
         );
@@ -187,8 +187,8 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Issue assets: {}", request);
 
-        Asset asset = fromAPI(request.getAsset());
-        FinIdAccount destination = fromAPI(request.getDestination());
+        FinIdAccount destination = finIdAccountFromAPI(request.getDestination());
+        Asset asset = assetFromAPI(request.getDestination());
         ExecutionContext exCtx = fromAPI(request.getExecutionContext());
 
         transactionHook.ifPresent(h -> h.preTransaction(
@@ -215,9 +215,9 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Transfer assets: {}", request);
 
-        Source source = fromAPI(request.getSource());
-        Destination destination = fromAPI(request.getDestination());
-        Asset asset = fromAPI(request.getAsset());
+        Source source = sourceFromAPI(request.getSource());
+        Destination destination = destinationFromAPI(request.getDestination());
+        Asset asset = assetFromAPI(request.getSource());
         Signature sig = fromAPI(request.getSignature());
         ExecutionContext exCtx = fromAPI(request.getExecutionContext());
 
@@ -251,8 +251,8 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Redeem assets: {}", request);
 
-        FinIdAccount source = fromAPI(request.getSource());
-        Asset asset = fromAPI(request.getAsset());
+        FinIdAccount source = finIdAccountFromAPI(request.getSource());
+        Asset asset = assetFromAPI(request.getSource());
         Signature sig = fromAPI(request.getSignature());
         ExecutionContext exCtx = fromAPI(request.getExecutionContext());
 
@@ -282,10 +282,11 @@ public class Controller {
 
     @PostMapping(value = "/api/assets/getBalance", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<APIGetAssetBalanceResponse> getBalance(@RequestBody APIGetAssetBalanceRequest request) {
-        Asset asset = fromAPI(request.getAsset());
+        // 0.28: asset is embedded in the APIAccount (owner)
+        Asset asset = assetFromAPI(request.getOwner());
         String balance = tokenService.getBalance(asset, request.getOwner().getFinId());
         return ResponseEntity.status(HttpStatus.OK).body(new APIGetAssetBalanceResponse()
-                .asset(request.getAsset())
+                .asset(request.getOwner().getAsset())
                 .balance(balance));
     }
 
@@ -323,9 +324,9 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Hold assets: {}", request);
 
-        Source source = fromAPI(request.getSource());
-        Destination destination = fromAPI(request.getDestination());
-        Asset asset = fromAPI(request.getAsset());
+        Source source = sourceFromAPI(request.getSource());
+        Destination destination = destinationFromAPI(request.getDestination());
+        Asset asset = assetFromAPI(request.getSource());
         Signature sig = fromAPI(request.getSignature());
         ExecutionContext exCtx = fromAPI(request.getExecutionContext());
 
@@ -359,9 +360,9 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Release assets: {}", request);
 
-        Source source = fromAPI(request.getSource());
-        Destination destination = fromAPI(request.getDestination());
-        Asset asset = fromAPI(request.getAsset());
+        Source source = sourceFromAPI(request.getSource());
+        Destination destination = destinationFromAPI(request.getDestination());
+        Asset asset = assetFromAPI(request.getSource());
         ExecutionContext exCtx = fromAPI(request.getExecutionContext());
 
         transactionHook.ifPresent(h -> h.preTransaction(
@@ -389,8 +390,8 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Rollback assets: {}", request);
 
-        Source source = fromAPI(request.getSource());
-        Asset asset = fromAPI(request.getAsset());
+        Source source = sourceFromAPI(request.getSource());
+        Asset asset = assetFromAPI(request.getSource());
         ExecutionContext exCtx = fromAPI(request.getExecutionContext());
 
         transactionHook.ifPresent(h -> h.preTransaction(
@@ -429,8 +430,8 @@ public class Controller {
                 "depositInstruction", computeInputsHash("depositInstruction", ik, request.toString()),
                 () -> paymentService.getDepositInstruction(
                         ik,
-                        fromAPI(request.getOwner()),
-                        fromAPI(request.getDestination()),
+                        sourceFromAPI(request.getOwner()),
+                        destinationFromAPI(request.getDestination()),
                         fromAPI(request.getAsset()),
                         request.getAmount(),
                         request.getDetails(),
@@ -450,9 +451,9 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Payout: {}", request);
 
-        Source source = fromAPI(request.getSource());
-        Destination destination = fromAPI(request.getDestination());
-        Asset asset = fromAPI(request.getAsset());
+        Source source = sourceFromAPI(request.getSource());
+        Destination destination = destinationFromAPI(request.getDestination());
+        Asset asset = fromAPI(request.getAsset()); // payout: asset is top-level APIPayoutAsset
         Signature sig = fromAPI(request.getSignature());
 
         // Uncomment to enable signature verification:

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -83,6 +83,23 @@ public class Mappers {
         return new FinIdAccount(account.getFinId());
     }
 
+    public static FinIdAccount finIdAccountFromAPI(APIAccount account) {
+        return new FinIdAccount(account.getFinId());
+    }
+
+    // --- DepositPayoutAccount (used by /payments endpoints; keeps a separate top-level asset) ---
+
+    public static Source sourceFromAPI(APIDepositPayoutAccount account) {
+        return new Source(account.getFinId(), new FinIdAccount(account.getFinId()));
+    }
+
+    public static Destination destinationFromAPI(@Nullable APIDepositPayoutAccount account) {
+        if (account == null) {
+            return null;
+        }
+        return new Destination(account.getFinId(), new FinIdAccount(account.getFinId()));
+    }
+
     public static Source sourceFromAPI(APIAccount account) {
         DestinationAccount ledgerAccount = ledgerAccountFromAPI(account);
         SourceAccount src = (ledgerAccount instanceof SourceAccount)


### PR DESCRIPTION
## v0.28 migration — sub-PR 2 of 5 (stacks on v0.28/mappers-rewrite)

### Changes
**Token endpoints** (issue/transfer/redeem/hold/release/rollback):
- Asset now extracted from APIAccount via `assetFromAPI(source|destination)` (embedded in 0.28)
- `sourceFromAPI(APIAccount)` / `destinationFromAPI(APIAccount)` replace old `fromAPI(APISource|APIDestination)`
- `finIdAccountFromAPI(APIAccount)` for endpoints that take FinIdAccount

**Payment endpoints** (depositInstruction/payout):
- Use APIDepositPayoutAccount (separate polymorphic wrapper, still has top-level asset)
- Added `sourceFromAPI(APIDepositPayoutAccount)` + `destinationFromAPI(APIDepositPayoutAccount)` to Mappers

**Other**:
- Drop `request.getAssetIdentifier()` in createAsset (removed from 0.28)
- `getBalance` endpoint: asset now lives in owner account (not separate field)

### Status
✅ Skeleton now compiles end-to-end

⏳ Sample adapter (DbLedger/DbStorage) and tests in sub-PRs 4-5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)