### PR TITLE
v0.28 sub-PR 3: sample-adapter tests + null-safe polymorphic deserializers

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractBusinessLogicTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractBusinessLogicTest.java
@@ -22,7 +22,7 @@ public abstract class AbstractBusinessLogicTest {
     @Test
     void shouldFailRollbackOnNonExistentHold() {
         String buyer = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, buyer, "1000"));
@@ -35,7 +35,7 @@ public abstract class AbstractBusinessLogicTest {
     void shouldFailReleaseOnNonExistentOperationId() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, buyer, "1000"));
@@ -48,7 +48,7 @@ public abstract class AbstractBusinessLogicTest {
     void shouldFailDoubleRelease() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -67,7 +67,7 @@ public abstract class AbstractBusinessLogicTest {
     void shouldFailDoubleRollback() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -86,7 +86,7 @@ public abstract class AbstractBusinessLogicTest {
     void shouldFailRollbackAfterRelease() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -102,7 +102,7 @@ public abstract class AbstractBusinessLogicTest {
     @Test
     void shouldRetrieveReceiptByTransactionId() {
         String finId = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         APIReceiptOperation issueOp = api.issue(issueRequest(asset, finId, "100"));

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractEscrowOperationsTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractEscrowOperationsTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractEscrowOperationsTest {
     void shouldHoldAndReleaseFunds() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -47,7 +47,7 @@ public abstract class AbstractEscrowOperationsTest {
     @Test
     void shouldHoldAndRedeemTokens() {
         String investor = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -68,7 +68,7 @@ public abstract class AbstractEscrowOperationsTest {
     void shouldRollbackHeldFunds() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -85,7 +85,7 @@ public abstract class AbstractEscrowOperationsTest {
     void shouldPartiallyReleaseFunds() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String operationId = randomId();
 
         api.createAsset(createAssetRequest(asset));

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractInsufficientBalanceTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractInsufficientBalanceTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractInsufficientBalanceTest {
     void shouldFailTransferExceedingBalance() {
         String seller = randomFinId();
         String buyer = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, seller, "100"));
@@ -39,7 +39,7 @@ public abstract class AbstractInsufficientBalanceTest {
     void shouldFailTransferExactBalancePlusOne() {
         String seller = randomFinId();
         String buyer = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, seller, "500"));
@@ -54,7 +54,7 @@ public abstract class AbstractInsufficientBalanceTest {
     @Test
     void shouldFailRedeemExceedingBalance() {
         String investor = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, investor, "100"));
@@ -68,7 +68,7 @@ public abstract class AbstractInsufficientBalanceTest {
     @Test
     void shouldFailRedeemFromZeroBalance() {
         String investor = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
 
@@ -82,7 +82,7 @@ public abstract class AbstractInsufficientBalanceTest {
     void shouldFailHoldExceedingBalance() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String opId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -98,7 +98,7 @@ public abstract class AbstractInsufficientBalanceTest {
     void shouldFailHoldFromZeroBalance() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
         String opId = randomId();
 
         api.createAsset(createAssetRequest(asset));
@@ -113,7 +113,7 @@ public abstract class AbstractInsufficientBalanceTest {
     void shouldFailSecondHoldAfterPartialConsumption() {
         String buyer = randomFinId();
         String seller = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, buyer, "1000"));
@@ -132,7 +132,7 @@ public abstract class AbstractInsufficientBalanceTest {
         String owner = randomFinId();
         String recipient1 = randomFinId();
         String recipient2 = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, owner, "100"));

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractTokenLifecycleTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractTokenLifecycleTest.java
@@ -23,7 +23,7 @@ public abstract class AbstractTokenLifecycleTest {
     void shouldIssueTransferAndVerifyBalances() {
         String issuer = randomFinId();
         String buyer = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
 
@@ -46,7 +46,7 @@ public abstract class AbstractTokenLifecycleTest {
     @Test
     void shouldIssueAndRedeemTokens() {
         String issuer = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
 
@@ -66,7 +66,7 @@ public abstract class AbstractTokenLifecycleTest {
         String alice = randomFinId();
         String bob = randomFinId();
         String charlie = randomFinId();
-        APIFinp2pAsset asset = finp2pAsset();
+        APIAsset asset = finp2pAsset();
 
         api.createAsset(createAssetRequest(asset));
         api.issue(issueRequest(asset, alice, "1000"));

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/TestHelpers.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/TestHelpers.java
@@ -88,11 +88,10 @@ public class TestHelpers {
         return resp.getBody();
     }
 
-    public APIGetAssetBalanceResponse getBalance(APIFinp2pAsset asset, String finId) {
+    public APIGetAssetBalanceResponse getBalance(APIAsset asset, String finId) {
+        // 0.28: owner is APIAccount with embedded asset
         APIGetAssetBalanceRequest req = new APIGetAssetBalanceRequest()
-                .asset(new APIAsset(asset))
-                .owner(new APISource().finId(finId)
-                        .account(new APIFinIdAccount().finId(finId).type(APIFinIdAccount.TypeEnum.FIN_ID)));
+                .owner(new APIAccount().finId(finId).asset(asset));
         ResponseEntity<APIGetAssetBalanceResponse> resp =
                 rest.postForEntity("/api/assets/getBalance", req, APIGetAssetBalanceResponse.class);
         assertEquals(200, resp.getStatusCodeValue());
@@ -108,7 +107,7 @@ public class TestHelpers {
 
     // --- Assertion helpers ---
 
-    public void assertBalance(String finId, APIFinp2pAsset asset, String expectedBalance) {
+    public void assertBalance(String finId, APIAsset asset, String expectedBalance) {
         APIGetAssetBalanceResponse balance = getBalance(asset, finId);
         assertNotNull(balance);
         assertEquals(expectedBalance, balance.getBalance(),
@@ -136,106 +135,94 @@ public class TestHelpers {
 
     // --- Request builders ---
 
-    public static APIFinp2pAsset finp2pAsset() {
-        return new APIFinp2pAsset()
-                .type(APIFinp2pAsset.TypeEnum.FINP2P)
+    /**
+     * 0.28: APIAsset is flat (resourceId + optional ledgerIdentifier), no more polymorphism.
+     */
+    public static APIAsset finp2pAsset() {
+        return new APIAsset()
                 .resourceId("bank101:102:unique-" + randomId());
     }
 
-    public static APIIssueAssetsRequest issueRequest(APIFinp2pAsset asset, String finId, String quantity) {
+    /**
+     * 0.28: Issue destination is APIAccount with embedded asset.
+     */
+    public static APIIssueAssetsRequest issueRequest(APIAsset asset, String finId, String quantity) {
         return new APIIssueAssetsRequest()
-                .asset(asset)
-                .destination(new APIFinIdAccount().finId(finId).type(APIFinIdAccount.TypeEnum.FIN_ID))
+                .destination(new APIAccount().finId(finId).asset(asset))
                 .quantity(quantity);
     }
 
-    public static APITransferAssetRequest transferRequest(APIFinp2pAsset asset,
+    /**
+     * 0.28: Transfer source/destination are APIAccount (with embedded asset); no top-level asset.
+     */
+    public static APITransferAssetRequest transferRequest(APIAsset asset,
                                                           String fromFinId, String toFinId, String quantity) {
         return new APITransferAssetRequest()
                 .nonce(randomId())
-                .asset(new APIAsset(asset))
-                .source(new APISource().finId(fromFinId)
-                        .account(new APIFinIdAccount().finId(fromFinId).type(APIFinIdAccount.TypeEnum.FIN_ID)))
-                .destination(new APIDestination().finId(toFinId)
-                        .account(new APIDestinationAccount(
-                                new APIFinIdAccount().finId(toFinId).type(APIFinIdAccount.TypeEnum.FIN_ID))))
+                .source(new APIAccount().finId(fromFinId).asset(asset))
+                .destination(new APIAccount().finId(toFinId).asset(asset))
                 .quantity(quantity)
-                .signature(new APISignature()
-                        .signature("0000")
-                        .hashFunc(APIHashFunction.KECCAK_256)
-                        .template(new APISignatureTemplate(
-                                new APIHashListTemplate()
-                                        .type(APIHashListTemplate.TypeEnum.HASH_LIST)
-                                        .hash("0000"))));
+                .signature(defaultSignature());
     }
 
-    public static APIHoldOperationRequest holdRequest(APIFinp2pAsset asset,
+    public static APIHoldOperationRequest holdRequest(APIAsset asset,
                                                       String sourceFinId, String destFinId,
                                                       String quantity, String operationId) {
         return new APIHoldOperationRequest()
                 .nonce(randomId())
-                .asset(new APIAsset(asset))
-                .source(new APISource().finId(sourceFinId)
-                        .account(new APIFinIdAccount().finId(sourceFinId).type(APIFinIdAccount.TypeEnum.FIN_ID)))
-                .destination(new APIDestination().finId(destFinId)
-                        .account(new APIDestinationAccount(
-                                new APIFinIdAccount().finId(destFinId).type(APIFinIdAccount.TypeEnum.FIN_ID))))
+                .source(new APIAccount().finId(sourceFinId).asset(asset))
+                .destination(new APIAccount().finId(destFinId).asset(asset))
                 .quantity(quantity)
                 .operationId(operationId)
-                .signature(new APISignature()
-                        .signature("0000")
-                        .hashFunc(APIHashFunction.KECCAK_256)
-                        .template(new APISignatureTemplate(
-                                new APIHashListTemplate()
-                                        .type(APIHashListTemplate.TypeEnum.HASH_LIST)
-                                        .hash("0000"))));
+                .signature(defaultSignature());
     }
 
-    public static APIReleaseOperationRequest releaseRequest(APIFinp2pAsset asset,
+    public static APIReleaseOperationRequest releaseRequest(APIAsset asset,
                                                             String sourceFinId, String destFinId,
                                                             String quantity, String operationId) {
         return new APIReleaseOperationRequest()
-                .asset(new APIAsset(asset))
-                .source(new APISource().finId(sourceFinId)
-                        .account(new APIFinIdAccount().finId(sourceFinId).type(APIFinIdAccount.TypeEnum.FIN_ID)))
-                .destination(new APIDestination().finId(destFinId)
-                        .account(new APIDestinationAccount(
-                                new APIFinIdAccount().finId(destFinId).type(APIFinIdAccount.TypeEnum.FIN_ID))))
+                .source(new APIAccount().finId(sourceFinId).asset(asset))
+                .destination(new APIAccount().finId(destFinId).asset(asset))
                 .quantity(quantity)
                 .operationId(operationId);
     }
 
-    public static APIRollbackOperationRequest rollbackRequest(APIFinp2pAsset asset,
+    public static APIRollbackOperationRequest rollbackRequest(APIAsset asset,
                                                               String sourceFinId,
                                                               String quantity, String operationId) {
         return new APIRollbackOperationRequest()
-                .asset(new APIAsset(asset))
-                .source(new APISource().finId(sourceFinId)
-                        .account(new APIFinIdAccount().finId(sourceFinId).type(APIFinIdAccount.TypeEnum.FIN_ID)))
+                .source(new APIAccount().finId(sourceFinId).asset(asset))
                 .quantity(quantity)
                 .operationId(operationId);
     }
 
-    public static APIRedeemAssetsRequest redeemRequest(APIFinp2pAsset asset,
+    /**
+     * 0.28: Redeem source is APIAccount with embedded asset.
+     */
+    public static APIRedeemAssetsRequest redeemRequest(APIAsset asset,
                                                        String sourceFinId, String quantity, String operationId) {
         return new APIRedeemAssetsRequest()
                 .nonce(randomId())
-                .asset(asset)
-                .source(new APIFinIdAccount().finId(sourceFinId).type(APIFinIdAccount.TypeEnum.FIN_ID))
+                .source(new APIAccount().finId(sourceFinId).asset(asset))
                 .quantity(quantity)
                 .operationId(operationId)
-                .signature(new APISignature()
-                        .signature("0000")
-                        .hashFunc(APIHashFunction.KECCAK_256)
-                        .template(new APISignatureTemplate(
-                                new APIHashListTemplate()
-                                        .type(APIHashListTemplate.TypeEnum.HASH_LIST)
-                                        .hash("0000"))));
+                .signature(defaultSignature());
     }
 
-    public static APICreateAssetRequest createAssetRequest(APIFinp2pAsset asset) {
+    public static APICreateAssetRequest createAssetRequest(APIAsset asset) {
+        // 0.28: createAsset takes APIFinp2pAssetBase (not full APIAsset)
         return new APICreateAssetRequest()
-                .asset(new APIAsset(asset));
+                .asset(new APIFinp2pAssetBase().resourceId(asset.getResourceId()));
+    }
+
+    private static APISignature defaultSignature() {
+        return new APISignature()
+                .signature("0000")
+                .hashFunc(APIHashFunction.KECCAK_256)
+                .template(new APISignatureTemplate(
+                        new APIHashListTemplate()
+                                .type(APIHashListTemplate.TypeEnum.HASHLIST)
+                                .hash("0000")));
     }
 
     private <T> HttpEntity<T> withIdempotencyKey(T body) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIAccountLedgerAccount.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIAccountLedgerAccount.java
@@ -131,7 +131,7 @@ public class APIAccountLedgerAccount extends AbstractOpenApiSchema {
          */
         @Override
         public APIAccountLedgerAccount getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIAccountLedgerAccount cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIBalanceMarker.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIBalanceMarker.java
@@ -158,7 +158,7 @@ public class APIBalanceMarker extends AbstractOpenApiSchema {
          */
         @Override
         public APIBalanceMarker getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIBalanceMarker cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APICallbackResultsStrategyCallback.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APICallbackResultsStrategyCallback.java
@@ -131,7 +131,7 @@ public class APICallbackResultsStrategyCallback extends AbstractOpenApiSchema {
          */
         @Override
         public APICallbackResultsStrategyCallback getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APICallbackResultsStrategyCallback cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIContractDetailsAdditionalContractDetails.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIContractDetailsAdditionalContractDetails.java
@@ -103,7 +103,7 @@ public class APIContractDetailsAdditionalContractDetails extends AbstractOpenApi
          */
         @Override
         public APIContractDetailsAdditionalContractDetails getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIContractDetailsAdditionalContractDetails cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIDepositAsset.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIDepositAsset.java
@@ -158,7 +158,7 @@ public class APIDepositAsset extends AbstractOpenApiSchema {
          */
         @Override
         public APIDepositAsset getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIDepositAsset cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIDepositPayoutAccountAccount.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIDepositPayoutAccountAccount.java
@@ -131,7 +131,7 @@ public class APIDepositPayoutAccountAccount extends AbstractOpenApiSchema {
          */
         @Override
         public APIDepositPayoutAccountAccount getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIDepositPayoutAccountAccount cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIEIP712TypedValue.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIEIP712TypedValue.java
@@ -229,7 +229,7 @@ public class APIEIP712TypedValue extends AbstractOpenApiSchema {
          */
         @Override
         public APIEIP712TypedValue getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIEIP712TypedValue cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIExecutionPlanProposalRequestExecutionPlanProposal.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIExecutionPlanProposalRequestExecutionPlanProposal.java
@@ -185,7 +185,7 @@ public class APIExecutionPlanProposalRequestExecutionPlanProposal extends Abstra
          */
         @Override
         public APIExecutionPlanProposalRequestExecutionPlanProposal getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIExecutionPlanProposalRequestExecutionPlanProposal cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APILedgerAssetBinding.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APILedgerAssetBinding.java
@@ -131,7 +131,7 @@ public class APILedgerAssetBinding extends AbstractOpenApiSchema {
          */
         @Override
         public APILedgerAssetBinding getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APILedgerAssetBinding cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APILedgerAssetIdentifier.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APILedgerAssetIdentifier.java
@@ -131,7 +131,7 @@ public class APILedgerAssetIdentifier extends AbstractOpenApiSchema {
          */
         @Override
         public APILedgerAssetIdentifier getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APILedgerAssetIdentifier cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APILedgerAssetInfoLedgerReference.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APILedgerAssetInfoLedgerReference.java
@@ -132,7 +132,7 @@ public class APILedgerAssetInfoLedgerReference extends AbstractOpenApiSchema {
          */
         @Override
         public APILedgerAssetInfoLedgerReference getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APILedgerAssetInfoLedgerReference cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIOperationMetadataOperationResponseStrategy.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIOperationMetadataOperationResponseStrategy.java
@@ -160,7 +160,7 @@ public class APIOperationMetadataOperationResponseStrategy extends AbstractOpenA
          */
         @Override
         public APIOperationMetadataOperationResponseStrategy getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIOperationMetadataOperationResponseStrategy cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIOperationStatus.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIOperationStatus.java
@@ -213,7 +213,7 @@ public class APIOperationStatus extends AbstractOpenApiSchema {
          */
         @Override
         public APIOperationStatus getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIOperationStatus cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPaymentMethodMethodInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPaymentMethodMethodInstruction.java
@@ -213,7 +213,7 @@ public class APIPaymentMethodMethodInstruction extends AbstractOpenApiSchema {
          */
         @Override
         public APIPaymentMethodMethodInstruction getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIPaymentMethodMethodInstruction cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPlanApprovalResponseApproval.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPlanApprovalResponseApproval.java
@@ -159,7 +159,7 @@ public class APIPlanApprovalResponseApproval extends AbstractOpenApiSchema {
          */
         @Override
         public APIPlanApprovalResponseApproval getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIPlanApprovalResponseApproval cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPlanRejectedFailure.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPlanRejectedFailure.java
@@ -161,7 +161,7 @@ public class APIPlanRejectedFailure extends AbstractOpenApiSchema {
          */
         @Override
         public APIPlanRejectedFailure getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIPlanRejectedFailure cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPollingResultsStrategyPolling.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIPollingResultsStrategyPolling.java
@@ -186,7 +186,7 @@ public class APIPollingResultsStrategyPolling extends AbstractOpenApiSchema {
          */
         @Override
         public APIPollingResultsStrategyPolling getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIPollingResultsStrategyPolling cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIProofPolicy.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIProofPolicy.java
@@ -159,7 +159,7 @@ public class APIProofPolicy extends AbstractOpenApiSchema {
          */
         @Override
         public APIProofPolicy getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIProofPolicy cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APISignatureTemplate.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APISignatureTemplate.java
@@ -166,7 +166,7 @@ public class APISignatureTemplate extends AbstractOpenApiSchema {
          */
         @Override
         public APISignatureTemplate getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APISignatureTemplate cannot be null");
+            return null;
         }
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIWireDetails.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIWireDetails.java
@@ -185,7 +185,7 @@ public class APIWireDetails extends AbstractOpenApiSchema {
          */
         @Override
         public APIWireDetails getNullValue(DeserializationContext ctxt) throws JsonMappingException {
-            throw new JsonMappingException(ctxt.getParser(), "APIWireDetails cannot be null");
+            return null;
         }
     }
 


### PR DESCRIPTION
## v0.28 migration — sub-PR 3 of 3 (final — stacks on v0.28/controller-update)

### Changes
**TestHelpers.java** — rewritten for new 0.28 API shapes:
- `APIFinp2pAsset` → `APIAsset` (polymorphism collapsed)
- `APISource`/`APIDestination`/`APIDestinationAccount` → `APIAccount` (embeds asset)
- `APIFinIdAccount.TypeEnum.FIN_ID` → `APIFinIdAccountBase.TypeEnum.FINID`
- `APIHashListTemplate.TypeEnum.HASH_LIST` → `HASHLIST`
- createAsset uses `APIFinp2pAssetBase` (base type, not full `APIAsset`)

**Abstract test classes** — bulk rename `APIFinp2pAsset` → `APIAsset`

**Null-safe polymorphic deserializers** — 20 generator-emitted classes had `getNullValue()` throwing for null input. Now returns `null`, allowing optional polymorphic fields (like `ledgerAssetBinding` in `createAsset`) to be omitted.

### Status
✅ All 30 Postgres tests pass

### Migration complete
With this merge chain (#28 → #29 → this), feature/v0.28 is functionally complete and tests green. DefaultPlanApprovalService needed no changes (uses Java SDK opapi types, decoupled from adapter API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)