### PR TITLE
v0.28 align B: carry ledgerIdentifier (CAIP-19) through Asset model

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -19,11 +19,23 @@ public class Mappers {
         if (asset == null) {
             throw new MappingException("Asset is required");
         }
-        return new Asset(asset.getResourceId(), AssetType.FINP2P);
+        return new Asset(asset.getResourceId(), AssetType.FINP2P, fromAPI(asset.getLedgerIdentifier()));
     }
 
     public static Asset fromAPI(APIFinp2pAssetBase asset) {
         return new Asset(asset.getResourceId(), AssetType.FINP2P);
+    }
+
+    public static LedgerAssetIdentifier fromAPI(@Nullable APILedgerAssetIdentifier identifier) {
+        if (identifier == null) {
+            return null;
+        }
+        Object actual = identifier.getActualInstance();
+        if (actual instanceof APILedgerAssetIdentifierTypeCAIP19) {
+            APILedgerAssetIdentifierTypeCAIP19 caip19 = (APILedgerAssetIdentifierTypeCAIP19) actual;
+            return new LedgerAssetIdentifier(caip19.getNetwork(), caip19.getTokenId(), caip19.getStandard());
+        }
+        return null;
     }
 
     public static AssetBind fromAPI(@Nullable APILedgerAssetBinding binding) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/Asset.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/Asset.java
@@ -1,11 +1,20 @@
 package io.ownera.ledger.adapter.service.model;
 
+import javax.annotation.Nullable;
+
 public class Asset {
     public final String assetId;
     public final AssetType assetType;
+    @Nullable
+    public final LedgerAssetIdentifier ledgerIdentifier;
 
     public Asset(String assetId, AssetType assetType) {
+        this(assetId, assetType, null);
+    }
+
+    public Asset(String assetId, AssetType assetType, @Nullable LedgerAssetIdentifier ledgerIdentifier) {
         this.assetId = assetId;
         this.assetType = assetType;
+        this.ledgerIdentifier = ledgerIdentifier;
     }
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/LedgerAssetIdentifier.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/LedgerAssetIdentifier.java
@@ -1,0 +1,20 @@
+package io.ownera.ledger.adapter.service.model;
+
+import javax.annotation.Nullable;
+
+/**
+ * CAIP-19 ledger asset identifier.
+ * Aligns with the Node.js skeleton's {@code Caip19LedgerAssetIdentifier} type.
+ */
+public class LedgerAssetIdentifier {
+    public final String network;
+    public final String tokenId;
+    @Nullable
+    public final String standard;
+
+    public LedgerAssetIdentifier(String network, String tokenId, @Nullable String standard) {
+        this.network = network;
+        this.tokenId = tokenId;
+        this.standard = standard;
+    }
+}


### PR DESCRIPTION
## Alignment sub-PR B — Node.js cross-check follow-up (stacks on align A #31)

Brings internal `Asset` model to parity with Node.js skeleton.

### Changes
- New `service.model.LedgerAssetIdentifier` class (CAIP-19: network + tokenId + standard)
- `Asset` now carries optional `ledgerIdentifier` field (backward-compat constructor preserved)
- `Mappers.fromAPI(APIAsset)` populates it from `APILedgerAssetIdentifier`
- New `Mappers.fromAPI(APILedgerAssetIdentifier)` helper

Adapters previously lost the CAIP-19 identifier during API → internal conversion. Now it's available via `asset.ledgerIdentifier` — matches Node.js skeleton's `Asset.ledgerIdentifier`.

### Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)