### PR TITLE
v0.28 align C: typed PlanProposal union for proposalStatus

### DIFF
--- a/sample-adapter/src/main/java/io/ownera/ledger/adapter/sample/AutoPlanApprovalService.java
+++ b/sample-adapter/src/main/java/io/ownera/ledger/adapter/sample/AutoPlanApprovalService.java
@@ -3,6 +3,8 @@ package io.ownera.ledger.adapter.sample;
 import io.ownera.ledger.adapter.service.PlanApprovalService;
 import io.ownera.ledger.adapter.service.model.ApprovedPlan;
 import io.ownera.ledger.adapter.service.model.PlanApprovalStatus;
+import io.ownera.ledger.adapter.service.model.PlanProposal;
+import io.ownera.ledger.adapter.service.model.ProposalStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,7 +40,7 @@ public class AutoPlanApprovalService implements PlanApprovalService {
     }
 
     @Override
-    public void proposalStatus(String planId, String status, String requestType) {
-        logger.info("Proposal status: plan={}, status={}, type={}", planId, status, requestType);
+    public void proposalStatus(String planId, PlanProposal proposal, ProposalStatus status) {
+        logger.info("Proposal status: plan={}, status={}, type={}", planId, status, proposal.getClass().getSimpleName());
     }
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
@@ -142,12 +142,12 @@ public class Controller {
             @RequestBody APIExecutionPlanProposalStatusRequest request
     ) {
         String planId = request.getRequest().getExecutionPlan().getId();
-        String status = request.getStatus() != null ? request.getStatus().getValue() : "unknown";
-        String requestType = request.getRequest().getExecutionPlan().getProposal() != null
-                ? request.getRequest().getExecutionPlan().getProposal().getActualInstance().getClass().getSimpleName()
-                : "unknown";
-        logger.info("Proposal status: planId={}, status={}, type={}", planId, status, requestType);
-        planApprovalService.proposalStatus(planId, status, requestType);
+        PlanProposal proposal = proposalFromAPI(request.getRequest().getExecutionPlan().getProposal());
+        ProposalStatus status = "rejected".equalsIgnoreCase(
+                request.getStatus() != null ? request.getStatus().getValue() : null)
+                ? ProposalStatus.REJECTED : ProposalStatus.APPROVED;
+        logger.info("Proposal status: planId={}, status={}, type={}", planId, status, proposal.getClass().getSimpleName());
+        planApprovalService.proposalStatus(planId, proposal, status);
         return ResponseEntity.noContent().build();
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -155,6 +155,27 @@ public class Mappers {
         return new Destination(account.getFinId(), new FinIdAccount(account.getFinId()));
     }
 
+    // --- Plan proposal mapping ---
+
+    public static PlanProposal proposalFromAPI(@Nullable APIExecutionPlanProposalRequestExecutionPlanProposal proposal) {
+        if (proposal == null) {
+            return PlanProposalCancel.INSTANCE; // unknown proposal defaults to cancel-shaped
+        }
+        Object actual = proposal.getActualInstance();
+        if (actual instanceof APIExecutionPlanCancellationProposal) {
+            return PlanProposalCancel.INSTANCE;
+        }
+        if (actual instanceof APIExecutionPlanResetProposal) {
+            APIExecutionPlanResetProposal reset = (APIExecutionPlanResetProposal) actual;
+            return new PlanProposalReset(reset.getProposedSequence() != null ? reset.getProposedSequence() : 0);
+        }
+        if (actual instanceof APIExecutionPlanInstructionProposal) {
+            APIExecutionPlanInstructionProposal instr = (APIExecutionPlanInstructionProposal) actual;
+            return new PlanProposalInstruction(instr.getInstructionSequence() != null ? instr.getInstructionSequence() : 0);
+        }
+        throw new MappingException("Unsupported proposal type: " + actual.getClass().getName());
+    }
+
     public static ExecutionContext fromAPI(@Nullable APIExecutionContext ctx) {
         if (ctx == null) {
             return null;

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/PlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/PlanApprovalService.java
@@ -1,6 +1,8 @@
 package io.ownera.ledger.adapter.service;
 
 import io.ownera.ledger.adapter.service.model.PlanApprovalStatus;
+import io.ownera.ledger.adapter.service.model.PlanProposal;
+import io.ownera.ledger.adapter.service.model.ProposalStatus;
 
 public interface PlanApprovalService {
 
@@ -12,5 +14,12 @@ public interface PlanApprovalService {
 
     PlanApprovalStatus proposeInstructionApproval(String idempotencyKey, String planId, int instructionSequence);
 
-    void proposalStatus(String planId, String status, String requestType);
+    /**
+     * Notification that a previously-returned proposal outcome has been acknowledged by the router.
+     *
+     * @param planId   the execution plan ID
+     * @param proposal the typed proposal that was raised (cancel/reset/instruction)
+     * @param status   outcome (approved/rejected)
+     */
+    void proposalStatus(String planId, PlanProposal proposal, ProposalStatus status);
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposal.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposal.java
@@ -1,0 +1,8 @@
+package io.ownera.ledger.adapter.service.model;
+
+/**
+ * Sealed union of plan proposal types.
+ * Aligns with Node.js skeleton's {@code PlanProposal} discriminated union.
+ */
+public interface PlanProposal {
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposalCancel.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposalCancel.java
@@ -1,0 +1,8 @@
+package io.ownera.ledger.adapter.service.model;
+
+public final class PlanProposalCancel implements PlanProposal {
+    public static final PlanProposalCancel INSTANCE = new PlanProposalCancel();
+
+    private PlanProposalCancel() {
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposalInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposalInstruction.java
@@ -1,0 +1,9 @@
+package io.ownera.ledger.adapter.service.model;
+
+public final class PlanProposalInstruction implements PlanProposal {
+    public final int instructionSequence;
+
+    public PlanProposalInstruction(int instructionSequence) {
+        this.instructionSequence = instructionSequence;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposalReset.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/PlanProposalReset.java
@@ -1,0 +1,9 @@
+package io.ownera.ledger.adapter.service.model;
+
+public final class PlanProposalReset implements PlanProposal {
+    public final int proposedSequence;
+
+    public PlanProposalReset(int proposedSequence) {
+        this.proposedSequence = proposedSequence;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/ProposalStatus.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/ProposalStatus.java
@@ -1,0 +1,6 @@
+package io.ownera.ledger.adapter.service.model;
+
+public enum ProposalStatus {
+    APPROVED,
+    REJECTED
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
@@ -141,8 +141,8 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
     }
 
     @Override
-    public void proposalStatus(String planId, String status, String requestType) {
-        logger.info("Proposal status: plan={}, status={}, type={}", planId, status, requestType);
+    public void proposalStatus(String planId, PlanProposal proposal, ProposalStatus status) {
+        logger.info("Proposal status: plan={}, status={}, type={}", planId, status, proposal.getClass().getSimpleName());
     }
 
     private PlanApprovalStatus validatePlan(String idempotencyKey, String planId, Execution execution) {


### PR DESCRIPTION
## Alignment sub-PR C — Node.js cross-check follow-up (stacks on align B #32)

Replaces String-typed `proposalStatus(planId, String status, String requestType)` with a typed union matching Node.js skeleton.

### Changes
New sealed union in `service.model`:
- `PlanProposal` (interface)
- `PlanProposalCancel` (singleton `INSTANCE`)
- `PlanProposalReset` — carries `proposedSequence`
- `PlanProposalInstruction` — carries `instructionSequence`
- `ProposalStatus` enum (`APPROVED`/`REJECTED`)

`PlanApprovalService.proposalStatus(planId, PlanProposal, ProposalStatus)` — typed signature.

New `Mappers.proposalFromAPI` unwraps polymorphic `APIExecutionPlan*Proposal` → typed `PlanProposal`.

`AutoPlanApprovalService` + `DefaultPlanApprovalService` updated.

### Alignment with Node.js
```ts
// Node
proposalStatus(planId: string, proposal: PlanProposal, status: 'approved' | 'rejected')
// Java — now
proposalStatus(String planId, PlanProposal proposal, ProposalStatus status)
```

### Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)