### PR TITLE
v0.28 align D: FinIdAccount gains optional orgId/custodianOrgId

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/FinIdAccount.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/FinIdAccount.java
@@ -1,17 +1,38 @@
 package io.ownera.ledger.adapter.service.model;
 
+import javax.annotation.Nullable;
+
 public class FinIdAccount implements SourceAccount, DestinationAccount {
     public final String finId;
+    /**
+     * Organization ID that owns this FinID. Not carried by the 0.28 adapter API;
+     * adapters populate this from their own org lookup (e.g. via FinP2PSDK).
+     * Aligns with Node.js skeleton's FinIdAccount.orgId.
+     */
+    @Nullable
+    public final String orgId;
+    /**
+     * Custodian organization ID. Not carried by the 0.28 adapter API;
+     * adapters populate this externally.
+     */
+    @Nullable
+    public final String custodianOrgId;
 
     public FinIdAccount(String finId) {
+        this(finId, null, null);
+    }
+
+    public FinIdAccount(String finId, @Nullable String orgId, @Nullable String custodianOrgId) {
         this.finId = finId;
+        this.orgId = orgId;
+        this.custodianOrgId = custodianOrgId;
     }
 
     public Source source() {
-        return new Source(finId, new FinIdAccount(finId));
+        return new Source(finId, this);
     }
 
     public Destination destination() {
-        return new Destination(finId, new FinIdAccount(finId));
+        return new Destination(finId, this);
     }
 }


### PR DESCRIPTION
## Alignment sub-PR D — Node.js cross-check (stacks on align C #33)

Match Node.js skeleton's `FinIdAccount { finId, orgId, custodianOrgId }`.

### Changes
- `FinIdAccount` gains optional `orgId` and `custodianOrgId` (nullable)
- Backward-compat `FinIdAccount(String finId)` constructor preserved
- `source()` / `destination()` helpers now pass `this` (preserving org fields) instead of creating a new instance

### Context
The 0.28 adapter API does not carry org fields on accounts — adapters populate them externally (e.g. via `FinP2PSDK.getUserByFinId(finId)`). These nullable fields give adapters somewhere to carry the lookup result through the service layer.

### Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)