### PR TITLE
v0.28 align E: generic LedgerAccount {type, address}

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -129,13 +129,16 @@ public class Mappers {
 
     /**
      * Extract ledger account (wallet) from an APIAccount, falling back to FinIdAccount if none.
+     * Maps to a generic {@link LedgerAccount} carrying the type discriminator from the API
+     * (aligns with Node.js skeleton's LedgerAccount {type, address}).
      */
     private static DestinationAccount ledgerAccountFromAPI(APIAccount account) {
         if (account.getLedgerAccount() != null) {
             Object actual = account.getLedgerAccount().getActualInstance();
             if (actual instanceof APIWalletLedgerAccount) {
                 APIWalletLedgerAccount wallet = (APIWalletLedgerAccount) actual;
-                return new CryptocurrencyWallet(wallet.getAddress());
+                String type = wallet.getType() != null ? wallet.getType() : "wallet";
+                return new LedgerAccount(type, wallet.getAddress());
             }
         }
         return new FinIdAccount(account.getFinId());
@@ -572,13 +575,9 @@ public class Mappers {
         if (asset != null) {
             account.asset(toAPIAsset(asset));
         }
-        if (source.account instanceof CryptocurrencyWallet) {
-            CryptocurrencyWallet wallet = (CryptocurrencyWallet) source.account;
-            account.ledgerAccount(new APIAccountLedgerAccount(
-                    new APIWalletLedgerAccount()
-                            .type("wallet")
-                            .address(wallet.address)
-            ));
+        APIAccountLedgerAccount ledger = toAPILedger(source.account);
+        if (ledger != null) {
+            account.ledgerAccount(ledger);
         }
         return account;
     }
@@ -591,15 +590,23 @@ public class Mappers {
         if (asset != null) {
             account.asset(toAPIAsset(asset));
         }
-        if (destination.account instanceof CryptocurrencyWallet) {
-            CryptocurrencyWallet wallet = (CryptocurrencyWallet) destination.account;
-            account.ledgerAccount(new APIAccountLedgerAccount(
-                    new APIWalletLedgerAccount()
-                            .type("wallet")
-                            .address(wallet.address)
-            ));
+        APIAccountLedgerAccount ledger = toAPILedger(destination.account);
+        if (ledger != null) {
+            account.ledgerAccount(ledger);
         }
         return account;
+    }
+
+    private static APIAccountLedgerAccount toAPILedger(@Nullable Object account) {
+        if (account instanceof LedgerAccount) {
+            LedgerAccount la = (LedgerAccount) account;
+            return new APIAccountLedgerAccount(new APIWalletLedgerAccount().type(la.type).address(la.address));
+        }
+        if (account instanceof CryptocurrencyWallet) {
+            CryptocurrencyWallet wallet = (CryptocurrencyWallet) account;
+            return new APIAccountLedgerAccount(new APIWalletLedgerAccount().type("wallet").address(wallet.address));
+        }
+        return null;
     }
 
     private static APIFinIdAccountBase toAPI(FinIdAccount account) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/LedgerAccount.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/LedgerAccount.java
@@ -1,0 +1,16 @@
+package io.ownera.ledger.adapter.service.model;
+
+/**
+ * Generic ledger account reference with typed discriminator.
+ * Aligns with Node.js skeleton's {@code LedgerAccount {type, address}} — flexible alternative
+ * to concrete per-ledger wallet classes (e.g. {@link CryptocurrencyWallet}).
+ */
+public class LedgerAccount implements SourceAccount, DestinationAccount {
+    public final String type;
+    public final String address;
+
+    public LedgerAccount(String type, String address) {
+        this.type = type;
+        this.address = address;
+    }
+}


### PR DESCRIPTION
## Alignment sub-PR E — Node.js cross-check (stacks on align D #34)

Generic `LedgerAccount {type, address}` aligning with Node skeleton.

### Changes
- New `LedgerAccount` class (implements both `SourceAccount` + `DestinationAccount`) with `type` + `address`
- `Mappers.ledgerAccountFromAPI` now returns generic `LedgerAccount` preserving the type discriminator from `APIWalletLedgerAccount`
- New `toAPILedger()` helper handles both `LedgerAccount` (preferred) and legacy `CryptocurrencyWallet` (kept for backward compat)

### Alignment
```ts
// Node
export type LedgerAccount = { type: string; address: string };
// Java — now
public class LedgerAccount implements SourceAccount, DestinationAccount {
    public final String type;
    public final String address;
}
```

### Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)