### PR TITLE
v0.28 align F: add AccountMappingService interface

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/mapping/AccountMappingService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/mapping/AccountMappingService.java
@@ -1,0 +1,37 @@
+package io.ownera.ledger.adapter.service.mapping;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Service-layer contract for account mapping operations.
+ * Aligns with Node.js skeleton's {@code AccountMappingService}.
+ * <p>
+ * Thin service layer over {@link AccountMappingStore}: adapters can implement this
+ * directly to inject business logic (validation, lookup augmentation, etc.)
+ * or use {@link DefaultAccountMappingService} which delegates to a store.
+ */
+public interface AccountMappingService {
+
+    /**
+     * Get mappings for the given finIds, or all if {@code finIds} is null/empty.
+     */
+    List<AccountMapping> getAccounts(@Nullable List<String> finIds);
+
+    /**
+     * Reverse lookup: find finIds with a given field value.
+     */
+    List<AccountMapping> getByFieldValue(String fieldName, String value);
+
+    /**
+     * Upsert all field mappings for a finId.
+     * @return the persisted mapping (may differ from input if validator transformed fields)
+     */
+    AccountMapping saveAccount(String finId, Map<String, String> fields);
+
+    /**
+     * Delete all mappings for a finId, or a specific field if {@code fieldName} is provided.
+     */
+    void deleteAccount(String finId, @Nullable String fieldName);
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/mapping/DefaultAccountMappingService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/mapping/DefaultAccountMappingService.java
@@ -1,0 +1,54 @@
+package io.ownera.ledger.adapter.service.mapping;
+
+import javax.annotation.Nullable;
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * Default {@link AccountMappingService} implementation — thin delegate over
+ * {@link AccountMappingStore} with optional {@link MappingValidator}.
+ */
+public class DefaultAccountMappingService implements AccountMappingService {
+
+    private final AccountMappingStore store;
+    private final Optional<MappingValidator> validator;
+
+    public DefaultAccountMappingService(AccountMappingStore store) {
+        this(store, Optional.empty());
+    }
+
+    public DefaultAccountMappingService(AccountMappingStore store, Optional<MappingValidator> validator) {
+        this.store = store;
+        this.validator = validator;
+    }
+
+    @Override
+    public List<AccountMapping> getAccounts(@Nullable List<String> finIds) {
+        if (finIds == null || finIds.isEmpty()) {
+            return store.listAll();
+        }
+        return finIds.stream()
+                .map(store::getByFinId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<AccountMapping> getByFieldValue(String fieldName, String value) {
+        return store.getByFieldValue(fieldName, value);
+    }
+
+    @Override
+    public AccountMapping saveAccount(String finId, Map<String, String> fields) {
+        Map<String, String> validated = validator
+                .map(v -> v.validate(finId, fields))
+                .orElse(fields);
+        store.save(finId, validated);
+        return store.getByFinId(finId);
+    }
+
+    @Override
+    public void deleteAccount(String finId, @Nullable String fieldName) {
+        store.delete(finId, fieldName);
+    }
+}


### PR DESCRIPTION
## Alignment sub-PR F — Node.js cross-check (stacks on align E #35)

Introduces a service-layer abstraction over `AccountMappingStore`, aligning with Node.js skeleton's `AccountMappingService` contract.

### Changes
- New `AccountMappingService` interface (mirrors Node signatures):
  - `getAccounts(finIds?: List<String>)` → `List<AccountMapping>`
  - `getByFieldValue(fieldName, value)` → `List<AccountMapping>`
  - `saveAccount(finId, fields)` → `AccountMapping`
  - `deleteAccount(finId, fieldName?)` → `void`
- New `DefaultAccountMappingService` — thin delegate over `AccountMappingStore` + optional `MappingValidator`

### Approach
`AccountMappingStore` remains as the persistence-only interface (orthogonal concern). Adapters can opt into `AccountMappingService` for a cleaner layering matching Node. `MappingController` continues to work as-is; migrating it to use `AccountMappingService` is a future cleanup.

### Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)