### PR TITLE
v0.28 align G: plan instruction types in service.model.plan

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/AwaitInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/AwaitInstruction.java
@@ -1,0 +1,9 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+public final class AwaitInstruction implements ExecutionPlanOperation {
+    public final long waitUntil;
+
+    public AwaitInstruction(long waitUntil) {
+        this.waitUntil = waitUntil;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/ExecutionInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/ExecutionInstruction.java
@@ -1,0 +1,24 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Entry in an execution plan.
+ * Aligns with Node.js skeleton's {@code ExecutionInstruction}.
+ */
+public final class ExecutionInstruction {
+    public final int sequence;
+    public final List<String> organizations;
+    public final ExecutionPlanOperation operation;
+    @Nullable
+    public final Long timeout;
+
+    public ExecutionInstruction(int sequence, List<String> organizations, ExecutionPlanOperation operation, @Nullable Long timeout) {
+        this.sequence = sequence;
+        this.organizations = organizations != null ? organizations : Collections.emptyList();
+        this.operation = operation;
+        this.timeout = timeout;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/ExecutionPlanOperation.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/ExecutionPlanOperation.java
@@ -1,0 +1,11 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+/**
+ * Sealed union of execution plan operations.
+ * Aligns with Node.js skeleton's {@code ExecutionPlanOperation}.
+ * Implementers: {@link HoldInstruction}, {@link ReleaseInstruction},
+ * {@link IssueInstruction}, {@link TransferInstruction}, {@link RedemptionInstruction},
+ * {@link RevertHoldInstruction}, {@link AwaitInstruction}.
+ */
+public interface ExecutionPlanOperation {
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/HoldInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/HoldInstruction.java
@@ -1,0 +1,21 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+
+import javax.annotation.Nullable;
+
+public final class HoldInstruction implements ExecutionPlanOperation {
+    public final Asset asset;
+    public final FinIdAccount source;
+    @Nullable
+    public final FinIdAccount destination;
+    public final String amount;
+
+    public HoldInstruction(Asset asset, FinIdAccount source, @Nullable FinIdAccount destination, String amount) {
+        this.asset = asset;
+        this.source = source;
+        this.destination = destination;
+        this.amount = amount;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/IssueInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/IssueInstruction.java
@@ -1,0 +1,16 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+
+public final class IssueInstruction implements ExecutionPlanOperation {
+    public final Asset asset;
+    public final FinIdAccount destination;
+    public final String amount;
+
+    public IssueInstruction(Asset asset, FinIdAccount destination, String amount) {
+        this.asset = asset;
+        this.destination = destination;
+        this.amount = amount;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/RedemptionInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/RedemptionInstruction.java
@@ -1,0 +1,21 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+
+import javax.annotation.Nullable;
+
+public final class RedemptionInstruction implements ExecutionPlanOperation {
+    public final Asset asset;
+    public final FinIdAccount source;
+    @Nullable
+    public final FinIdAccount destination;
+    public final String amount;
+
+    public RedemptionInstruction(Asset asset, FinIdAccount source, @Nullable FinIdAccount destination, String amount) {
+        this.asset = asset;
+        this.source = source;
+        this.destination = destination;
+        this.amount = amount;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/ReleaseInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/ReleaseInstruction.java
@@ -1,0 +1,18 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+
+public final class ReleaseInstruction implements ExecutionPlanOperation {
+    public final Asset asset;
+    public final FinIdAccount source;
+    public final FinIdAccount destination;
+    public final String amount;
+
+    public ReleaseInstruction(Asset asset, FinIdAccount source, FinIdAccount destination, String amount) {
+        this.asset = asset;
+        this.source = source;
+        this.destination = destination;
+        this.amount = amount;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/RevertHoldInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/RevertHoldInstruction.java
@@ -1,0 +1,16 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+
+import javax.annotation.Nullable;
+
+public final class RevertHoldInstruction implements ExecutionPlanOperation {
+    @Nullable
+    public final FinIdAccount source;
+    public final FinIdAccount destination;
+
+    public RevertHoldInstruction(@Nullable FinIdAccount source, FinIdAccount destination) {
+        this.source = source;
+        this.destination = destination;
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/TransferInstruction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/plan/TransferInstruction.java
@@ -1,0 +1,18 @@
+package io.ownera.ledger.adapter.service.model.plan;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+
+public final class TransferInstruction implements ExecutionPlanOperation {
+    public final Asset asset;
+    public final FinIdAccount source;
+    public final FinIdAccount destination;
+    public final String amount;
+
+    public TransferInstruction(Asset asset, FinIdAccount source, FinIdAccount destination, String amount) {
+        this.asset = asset;
+        this.source = source;
+        this.destination = destination;
+        this.amount = amount;
+    }
+}


### PR DESCRIPTION
## Alignment sub-PR G — Node.js cross-check (stacks on align F #36)

Adds service-layer plan instruction types aligning with Node.js skeleton, enabling adapters to consume plan instructions without importing SDK `opapi.model` types directly.

### New package: `service.model.plan`
- `ExecutionPlanOperation` — sealed union interface
- `IssueInstruction`, `TransferInstruction`, `RedemptionInstruction` — source, destination, asset, amount
- `HoldInstruction` (destination optional), `ReleaseInstruction`
- `RevertHoldInstruction` (source optional)
- `AwaitInstruction` — waitUntil timestamp
- `ExecutionInstruction` — sequence + organizations + operation + optional timeout

### Approach
`DefaultPlanApprovalService` still uses SDK opapi types internally (that's the SDK's contract with the router). Adapters can now define **plugin interfaces / hooks** against these service-level types, decoupling their business logic from SDK specifics.

Alignment with Node:
```ts
// Node
export type ExecutionPlanOperation = HoldInstruction | ReleaseInstruction | IssueInstruction
  | TransferInstruction | AwaitInstruction | RevertHoldInstruction | RedemptionInstruction;
// Java — now
public interface ExecutionPlanOperation {} // sealed union
```

### Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)