### PR TITLE
Fix createAsset response: populate CAIP-19 discriminator + network/standard

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractTokenLifecycleTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractTokenLifecycleTest.java
@@ -25,7 +25,18 @@ public abstract class AbstractTokenLifecycleTest {
         String buyer = randomFinId();
         APIAsset asset = finp2pAsset();
 
-        api.createAsset(createAssetRequest(asset));
+        APICreateAssetResponse createResp = api.createAsset(createAssetRequest(asset));
+        // Lock in CAIP-19 discriminator on the response: FinP2P node rejects identifiers
+        // missing assetIdentifierType ("unknown discriminator value").
+        APILedgerAssetIdentifierTypeCAIP19 caip19 =
+                (APILedgerAssetIdentifierTypeCAIP19) createResp.getResponse().getLedgerAssetInfo()
+                        .getLedgerIdentifier().getActualInstance();
+        assert caip19.getAssetIdentifierType() == APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19
+                : "ledgerIdentifier missing CAIP-19 discriminator";
+        assert caip19.getTokenId() != null && !caip19.getTokenId().isEmpty()
+                : "ledgerIdentifier.tokenId is required";
+        assert caip19.getNetwork() != null : "ledgerIdentifier.network must be non-null";
+        assert caip19.getStandard() != null : "ledgerIdentifier.standard must be non-null";
 
         APIReceiptOperation issueOp = api.issue(issueRequest(asset, issuer, "1000"));
         APIReceipt issueReceipt = receipt(issueOp);

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -288,14 +288,25 @@ public class Mappers {
             operation.cid("");
             operation.response(new APIAssetCreateResponse()
                     .ledgerAssetInfo(new APILedgerAssetInfo()
-                            .ledgerIdentifier(new APILedgerAssetIdentifier(
-                                    new APILedgerAssetIdentifierTypeCAIP19()
-                                            .tokenId(success.result.tokenId)
-                            ))
+                            .ledgerIdentifier(toAPILedgerIdentifier(success.result))
                     ));
 
         }
         return operation;
+    }
+
+    /**
+     * Builds an APILedgerAssetIdentifier with the CAIP-19 discriminator and all
+     * required fields populated. The {@code assetIdentifierType} discriminator must
+     * be set to "CAIP-19" or downstream nodes reject the response.
+     */
+    private static APILedgerAssetIdentifier toAPILedgerIdentifier(AssetCreationResult result) {
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = new APILedgerAssetIdentifierTypeCAIP19()
+                .assetIdentifierType(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19)
+                .tokenId(result.tokenId)
+                .network(result.reference != null && result.reference.network != null ? result.reference.network : "")
+                .standard(result.reference != null && result.reference.tokenStandard != null ? result.reference.tokenStandard : "");
+        return new APILedgerAssetIdentifier(caip19);
     }
 
     public static APICreateAssetResponse toAPIResponse(AssetCreationStatus status) {
@@ -320,10 +331,7 @@ public class Mappers {
             response.setCid("");
             response.response(new APIAssetCreateResponse()
                     .ledgerAssetInfo(new APILedgerAssetInfo()
-                            .ledgerIdentifier(new APILedgerAssetIdentifier(
-                                    new APILedgerAssetIdentifierTypeCAIP19()
-                                            .tokenId(success.result.tokenId)
-                            ))
+                            .ledgerIdentifier(toAPILedgerIdentifier(success.result))
                     ));
 
         }


### PR DESCRIPTION
## Bug

`Mappers.toAPI(AssetCreationStatus)` / `toAPIResponse(AssetCreationStatus)` emit a `ledgerIdentifier` with only `tokenId` populated:

```json
"ledgerIdentifier": { "assetIdentifierType": null, "network": null, "tokenId": "0.0.8818701", "standard": null }
```

FinP2P node rejects this with **`unknown discriminator value ""`** — `assetIdentifierType` is the polymorphic discriminator and must be `"CAIP-19"`.

Compare with `finp2p-ethereum-adapter` (`src/services/direct/token-service.ts`) which builds the response with all four fields.

Adapters can't work around it — they don't own response serialization. Affects all Java skeleton consumers (Hedera, Canton, etc.).

## Fix

- New `toAPILedgerIdentifier(AssetCreationResult)` helper sets:
  - `assetIdentifierType` = `CAIP_19` (always)
  - `tokenId` from `result.tokenId`
  - `network` from `result.reference.network` (or `""` if no reference)
  - `standard` from `result.reference.tokenStandard` (or `""`)
- Both `toAPI` and `toAPIResponse` overloads now use it.
- New `AbstractTokenLifecycleTest` assertions lock the response shape — would have caught this regression.

## Status
✅ 30 Postgres tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)