### PR TITLE
Cover asset-creation response: polling test + SDK callback helper

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/MappersAssetCreationResponseTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/MappersAssetCreationResponseTest.java
@@ -1,0 +1,71 @@
+package io.ownera.ledger.adapter;
+
+import io.ownera.ledger.adapter.api.model.*;
+import io.ownera.ledger.adapter.service.model.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Unit tests covering the asset-creation response wire shape on every emission path.
+ * Regression coverage for the CAIP-19 discriminator bug (PR #39):
+ *   FinP2P node rejects ledgerIdentifier missing assetIdentifierType="CAIP-19".
+ *
+ * Three paths emit an asset-creation response:
+ *   1. Sync createAsset response — Mappers.toAPIResponse(AssetCreationStatus)
+ *   2. Operation-status polling — Mappers.toAPI(OperationStatus) wrapping AssetCreationStatus
+ *   3. Operational callback — Mappers.toSdkOperationStatus(OperationStatus) (sent via OperationalSDK)
+ */
+public class MappersAssetCreationResponseTest {
+
+    private static SuccessfulAssetCreation success() {
+        return new SuccessfulAssetCreation(new AssetCreationResult(
+                "0.0.8818701",
+                new LedgerReference("hedera:mainnet", "0.0.0", "HTS-fungible", null)
+        ));
+    }
+
+    private static void assertCaip19(APILedgerAssetIdentifier id) {
+        assertNotNull(id, "ledgerIdentifier must not be null");
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = (APILedgerAssetIdentifierTypeCAIP19) id.getActualInstance();
+        assertEquals(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19,
+                caip19.getAssetIdentifierType(), "assetIdentifierType discriminator must be CAIP-19");
+        assertEquals("0.0.8818701", caip19.getTokenId(), "tokenId");
+        assertEquals("hedera:mainnet", caip19.getNetwork(), "network");
+        assertEquals("HTS-fungible", caip19.getStandard(), "standard");
+    }
+
+    @Test
+    void syncCreateAssetResponseIncludesCaip19Discriminator() {
+        APICreateAssetResponse resp = Mappers.toAPIResponse(success());
+        assertCaip19(resp.getResponse().getLedgerAssetInfo().getLedgerIdentifier());
+    }
+
+    @Test
+    void pollingOperationStatusForAssetCreationIncludesCaip19Discriminator() {
+        // Upcast forces the OperationStatus overload (the polling path).
+        OperationStatus opStatus = success();
+        APIOperationStatus status = Mappers.toAPI(opStatus);
+        APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset) status.getActualInstance();
+        APICreateAssetOperation op = wrap.getOperation();
+        assertCaip19(op.getResponse().getLedgerAssetInfo().getLedgerIdentifier());
+    }
+
+    @Test
+    void sdkCallbackOperationStatusForAssetCreationIncludesCaip19Discriminator() {
+        // CallbackClient impls call OperationalSDK.sendCallbackResponse(cid, opapi.model.OperationStatus).
+        // Lock in the SDK type's CAIP-19 shape too.
+        io.ownera.finp2p.opapi.model.OperationStatus sdkStatus = Mappers.toSdkOperationStatus(success());
+        io.ownera.finp2p.opapi.model.OperationStatusCreateAsset wrap =
+                (io.ownera.finp2p.opapi.model.OperationStatusCreateAsset) sdkStatus.getActualInstance();
+        io.ownera.finp2p.opapi.model.LedgerAssetIdentifierTypeCAIP19 caip19 =
+                wrap.getOperation().getResponse().getLedgerAssetInfo().getLedgerIdentifier();
+        assertEquals(io.ownera.finp2p.opapi.model.LedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19,
+                caip19.getAssetIdentifierType(), "SDK assetIdentifierType discriminator must be CAIP-19");
+        assertEquals("0.0.8818701", caip19.getTokenId(), "SDK tokenId");
+        assertEquals("hedera:mainnet", caip19.getNetwork(), "SDK network");
+        assertEquals("HTS-fungible", caip19.getStandard(), "SDK standard");
+        assertEquals(io.ownera.finp2p.opapi.model.OperationStatusCreateAsset.TypeEnum.CREATE_ASSET,
+                wrap.getType(), "SDK OperationStatusCreateAsset.type must be CREATE_ASSET");
+    }
+}

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/TestHelpers.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/TestHelpers.java
@@ -105,6 +105,13 @@ public class TestHelpers {
         return resp.getBody();
     }
 
+    public APIOperationStatus getOperationStatus(String cid) {
+        ResponseEntity<APIOperationStatus> resp =
+                rest.getForEntity("/api/operations/status/" + cid, APIOperationStatus.class);
+        assertEquals(200, resp.getStatusCodeValue());
+        return resp.getBody();
+    }
+
     // --- Assertion helpers ---
 
     public void assertBalance(String finId, APIAsset asset, String expectedBalance) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -890,4 +890,57 @@ public class Mappers {
         }
         return new APIOperationMetadata().operationResponseStrategy(strategy);
     }
+
+    // --- Operational callback (SDK opapi.model) ---
+    // CallbackClient implementations call OperationalSDK.sendCallbackResponse(cid, opapi.model.OperationStatus).
+    // The SDK type is distinct from the skeleton's APIOperationStatus, so we provide a separate mapper here
+    // so adapters don't have to roll their own (and forget the CAIP-19 discriminator — see PR #39).
+
+    public static io.ownera.finp2p.opapi.model.OperationStatus toSdkOperationStatus(OperationStatus opStatus) {
+        if (opStatus instanceof AssetCreationStatus) {
+            return new io.ownera.finp2p.opapi.model.OperationStatus(toSdkCreateAssetOpWrap((AssetCreationStatus) opStatus));
+        }
+        throw new MappingException("toSdkOperationStatus: unsupported operation status type: " + opStatus.getClass().getName()
+                + " (currently only AssetCreationStatus is supported for callbacks; extend Mappers if other types are needed)");
+    }
+
+    private static io.ownera.finp2p.opapi.model.OperationStatusCreateAsset toSdkCreateAssetOpWrap(AssetCreationStatus status) {
+        return new io.ownera.finp2p.opapi.model.OperationStatusCreateAsset()
+                .type(io.ownera.finp2p.opapi.model.OperationStatusCreateAsset.TypeEnum.CREATE_ASSET)
+                .operation(toSdkCreateAssetOperation(status));
+    }
+
+    private static io.ownera.finp2p.opapi.model.CreateAssetOperation toSdkCreateAssetOperation(AssetCreationStatus status) {
+        io.ownera.finp2p.opapi.model.CreateAssetOperation op = new io.ownera.finp2p.opapi.model.CreateAssetOperation();
+        if (status instanceof PendingAssetCreation) {
+            PendingAssetCreation pending = (PendingAssetCreation) status;
+            op.isCompleted(false).cid(pending.correlationId);
+        } else if (status instanceof FailedAssetCreation) {
+            FailedAssetCreation failed = (FailedAssetCreation) status;
+            op.isCompleted(true).cid("")
+                    .error(new io.ownera.finp2p.opapi.model.CreateAssetOperationErrorInformation()
+                            .code(failed.details.code)
+                            .message(failed.details.message));
+        } else if (status instanceof SuccessfulAssetCreation) {
+            SuccessfulAssetCreation success = (SuccessfulAssetCreation) status;
+            op.isCompleted(true).cid("")
+                    .response(new io.ownera.finp2p.opapi.model.AssetCreateResponse()
+                            .ledgerAssetInfo(new io.ownera.finp2p.opapi.model.LedgerAssetInfo()
+                                    .ledgerIdentifier(toSdkLedgerIdentifier(success.result))));
+        }
+        return op;
+    }
+
+    /**
+     * Build the SDK's {@link io.ownera.finp2p.opapi.model.LedgerAssetIdentifierTypeCAIP19} with the
+     * {@code assetIdentifierType} discriminator set to CAIP-19 plus all fields populated.
+     * The downstream router rejects responses missing the discriminator (see PR #39).
+     */
+    private static io.ownera.finp2p.opapi.model.LedgerAssetIdentifierTypeCAIP19 toSdkLedgerIdentifier(AssetCreationResult result) {
+        return new io.ownera.finp2p.opapi.model.LedgerAssetIdentifierTypeCAIP19()
+                .assetIdentifierType(io.ownera.finp2p.opapi.model.LedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19)
+                .tokenId(result.tokenId)
+                .network(result.reference != null && result.reference.network != null ? result.reference.network : "")
+                .standard(result.reference != null && result.reference.tokenStandard != null ? result.reference.tokenStandard : "");
+    }
 }


### PR DESCRIPTION
## Context

PR #39 fixed the CAIP-19 discriminator on the **sync createAsset response**. The user flagged two adjacent paths that emit the same response type but were not covered by that fix:

1. **Polling** — `GET /api/operations/status/{cid}` when the operation is an asset creation
2. **Operational callback** — `CallbackClient` impls calling `OperationalSDK.sendCallbackResponse(cid, opapi.model.OperationStatus)`

## Validation against the API

| Path | Mapper used | Status |
|---|---|---|
| Sync `POST /api/assets/create` | `Mappers.toAPIResponse(AssetCreationStatus)` | ✅ Fixed in #39 |
| Polling `GET /api/operations/status/{cid}` | `Mappers.toAPI(OperationStatus)` → `toAPI(AssetCreationStatus)` | ✅ Transitively fixed by #39 — **now pinned by a test** |
| Callback `OperationalSDK.sendCallbackResponse(...)` | (no skeleton helper existed; adapters rolled their own) | ⚠️ **Not covered by #39** — fixed here |

## Changes

- **`Mappers.toSdkOperationStatus(OperationStatus)`** — builds the SDK's `opapi.model.OperationStatus` for asset creation with `assetIdentifierType = CAIP_19` plus `tokenId`/`network`/`standard` populated. Currently scoped to `AssetCreationStatus` (the bug we're fixing); throws `MappingException` for other types with a clear extension hint.
- **`TestHelpers.getOperationStatus(cid)`** — REST helper for `/api/operations/status/{cid}`.
- **`MappersAssetCreationResponseTest`** — three unit tests pinning the CAIP-19 wire shape on all three paths above:
  - sync `APICreateAssetResponse` (regression test for #39)
  - polling `APIOperationStatus` → `APIOperationStatusCreateAsset`
  - callback `opapi.model.OperationStatus` → `OperationStatusCreateAsset`

## Status
✅ 33 tests pass (was 30, +3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)