### PR TITLE
Fix APIHashFunction.fromValue("") regression

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/APIHashFunctionTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/APIHashFunctionTest.java
@@ -1,0 +1,43 @@
+package io.ownera.ledger.adapter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ownera.ledger.adapter.api.model.APIHashFunction;
+import io.ownera.ledger.adapter.api.model.APISignature;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * APIHashFunction.fromValue must accept empty string / null and map them to UNSPECIFIED.
+ * The router historically sends hashFunc="" for unsigned operations; throwing on that
+ * breaks request deserialization across all signed endpoints (issue/transfer/redeem/hold).
+ *
+ * Regression: this was fixed in 0.27.9 but lost during the 0.28 OpenAPI regen.
+ */
+public class APIHashFunctionTest {
+
+    @Test
+    void fromValueEmptyStringReturnsUnspecified() {
+        assertEquals(APIHashFunction.UNSPECIFIED, APIHashFunction.fromValue(""));
+    }
+
+    @Test
+    void fromValueNullReturnsUnspecified() {
+        assertEquals(APIHashFunction.UNSPECIFIED, APIHashFunction.fromValue(null));
+    }
+
+    @Test
+    void deserializeSignatureWithEmptyHashFuncDoesNotThrow() throws Exception {
+        // Reproduces the Hedera adapter incident: router posted hashFunc="" and Jackson
+        // failed inside APIHashFunction.fromValue.
+        String json = "{\"signature\":\"0x00\",\"hashFunc\":\"\",\"template\":{\"type\":\"hashList\",\"hash\":\"0x00\",\"hashGroups\":[]}}";
+        APISignature sig = new ObjectMapper().readValue(json, APISignature.class);
+        assertEquals(APIHashFunction.UNSPECIFIED, sig.getHashFunc());
+    }
+
+    @Test
+    void fromValueUnknownStillThrows() {
+        // Sanity: only empty/null are special-cased; truly unknown values still surface as errors.
+        assertThrows(IllegalArgumentException.class, () -> APIHashFunction.fromValue("md5"));
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIHashFunction.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/api/model/APIHashFunction.java
@@ -61,6 +61,11 @@ public enum APIHashFunction {
 
   @JsonCreator
   public static APIHashFunction fromValue(String value) {
+    // Router historically sends "" or null to mean "unspecified". Default to UNSPECIFIED
+    // instead of throwing — see 0.27.9 fix; lost during the 0.28 OpenAPI regen.
+    if (value == null || value.isEmpty()) {
+      return UNSPECIFIED;
+    }
     for (APIHashFunction b : APIHashFunction.values()) {
       if (b.value.equals(value)) {
         return b;


### PR DESCRIPTION
## Bug

Router posts `"hashFunc": ""` for unsigned operations. `APIHashFunction.fromValue("")` throws — breaks every signed-endpoint request (issue/transfer/redeem/hold/release/rollback) with:

```
Cannot construct instance of `APIHashFunction`, problem: Unexpected value ''
```

Reported from the Hedera adapter on the v0.28 line. This was originally fixed in **0.27.9** but the patch was lost during the 0.28 OpenAPI regen (the generator produced a vanilla `fromValue` that throws on unknowns).

## Fix

- `APIHashFunction.fromValue`: empty/null → `UNSPECIFIED`. Truly unknown values still throw (sanity preserved).
- New `APIHashFunctionTest` (4 tests): empty, null, full Jackson deserialization of an `APISignature` payload, and confirmation that genuinely unknown values still surface as errors.

## Status
✅ 37 tests pass (was 33, +4 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)