### PR TITLE
Fix receipt response: emit CAIP-19 discriminator on embedded asset

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractTokenLifecycleTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/AbstractTokenLifecycleTest.java
@@ -42,6 +42,13 @@ public abstract class AbstractTokenLifecycleTest {
         APIReceipt issueReceipt = receipt(issueOp);
         assert issueReceipt.getQuantity().equals("1000");
         assert issueReceipt.getOperationType() == APIOperationType.ISSUE;
+        // Receipt's destination.asset.ledgerIdentifier must carry the CAIP-19 discriminator —
+        // FinP2P node rejects null with code 999 "unknown discriminator value".
+        APILedgerAssetIdentifierTypeCAIP19 issueRcptCaip19 =
+                (APILedgerAssetIdentifierTypeCAIP19) issueReceipt.getDestination().getAsset()
+                        .getLedgerIdentifier().getActualInstance();
+        assert issueRcptCaip19.getAssetIdentifierType() == APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19
+                : "issue receipt destination.asset.ledgerIdentifier must have CAIP-19 discriminator";
 
         api.assertBalance(issuer, asset, "1000");
 

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/MappersReceiptResponseTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/MappersReceiptResponseTest.java
@@ -1,0 +1,89 @@
+package io.ownera.ledger.adapter;
+
+import io.ownera.ledger.adapter.api.model.*;
+import io.ownera.ledger.adapter.service.model.*;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Receipt responses (issue/transfer/redeem/hold/release/rollback) embed the asset in
+ * destination/source. The asset's ledgerIdentifier is a polymorphic union; the FinP2P
+ * node rejects responses where it serializes as null with code 999
+ * "unknown discriminator value: ".
+ *
+ * Pin the wire shape across all paths that return APIReceipt.
+ */
+public class MappersReceiptResponseTest {
+
+    private static Asset assetWithLedger() {
+        return new Asset(
+                "org-a:102:2c882096-3a49-453a-a0a5-9a09cc1a182c",
+                AssetType.FINP2P,
+                new LedgerAssetIdentifier("hedera:testnet", "0.0.8823890", "HTS"));
+    }
+
+    private static Asset assetWithoutLedger() {
+        // Adapters that don't track CAIP-19 still need the discriminator emitted.
+        return new Asset("org-a:102:bare", AssetType.FINP2P);
+    }
+
+    private static Receipt issueReceipt(Asset asset) {
+        FinIdAccount destination = new FinIdAccount("024e5be4e07c92f492b3c9680fd249a2b8004209ef8bb167421182a1bc0e94f264");
+        return new Receipt(
+                "0.0.7427478@1777525274.073000790",
+                OperationType.ISSUE,
+                asset,
+                null,
+                destination.destination(),
+                "30",
+                new TransactionDetails("0.0.7427478@1777525274.073000790", null),
+                new TradeDetails(new ExecutionContext("org-a:106:plan", 2)),
+                null,
+                1777525286354L);
+    }
+
+    private static APILedgerAssetIdentifierTypeCAIP19 caip19FromReceipt(APIReceipt apiReceipt) {
+        return (APILedgerAssetIdentifierTypeCAIP19)
+                apiReceipt.getDestination().getAsset().getLedgerIdentifier().getActualInstance();
+    }
+
+    @Test
+    void issueReceiptResponseIncludesCaip19Discriminator() {
+        ReceiptOperation rcptOp = new SuccessReceiptStatus(issueReceipt(assetWithLedger()));
+        APIReceiptOperation api = Mappers.toAPI(rcptOp);
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = caip19FromReceipt(api.getResponse());
+
+        assertEquals(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19,
+                caip19.getAssetIdentifierType(), "discriminator must be CAIP-19");
+        assertEquals("hedera:testnet", caip19.getNetwork());
+        assertEquals("0.0.8823890", caip19.getTokenId());
+        assertEquals("HTS", caip19.getStandard());
+    }
+
+    @Test
+    void receiptWithAssetMissingLedgerIdentifierStillEmitsDiscriminator() {
+        // Older adapter code paths may produce Asset without ledgerIdentifier; the wire
+        // shape must still carry the discriminator (empty strings) — anything but null.
+        ReceiptOperation rcptOp = new SuccessReceiptStatus(issueReceipt(assetWithoutLedger()));
+        APIReceiptOperation api = Mappers.toAPI(rcptOp);
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = caip19FromReceipt(api.getResponse());
+
+        assertNotNull(caip19, "ledgerIdentifier must not be null");
+        assertEquals(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19,
+                caip19.getAssetIdentifierType());
+        assertEquals("", caip19.getNetwork());
+        assertEquals("", caip19.getTokenId());
+        assertEquals("", caip19.getStandard());
+    }
+
+    @Test
+    void getReceiptResponseAlsoIncludesCaip19() {
+        // GET /api/assets/receipts/{id} uses toAPIGetReceiptResponse — same code path.
+        ReceiptOperation rcptOp = new SuccessReceiptStatus(issueReceipt(assetWithLedger()));
+        APIGetReceiptResponse resp = Mappers.toAPIGetReceiptResponse(rcptOp);
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = caip19FromReceipt(resp.getResponse());
+        assertEquals(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19,
+                caip19.getAssetIdentifierType());
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -624,8 +624,22 @@ public class Mappers {
     }
 
     private static APIAsset toAPIAsset(Asset asset) {
-        return new APIAsset()
-                .resourceId(asset.assetId);
+        APIAsset apiAsset = new APIAsset().resourceId(asset.assetId);
+        // ledgerIdentifier is a polymorphic union; the FinP2P node decoder treats null as
+        // "unknown discriminator value" and rejects the response with code 999. Always emit
+        // a CAIP-19 wrapper. Source the fields from the internal LedgerAssetIdentifier when
+        // present (carried in by the request), or fall back to empty strings.
+        apiAsset.ledgerIdentifier(toAPILedgerIdentifier(asset.ledgerIdentifier));
+        return apiAsset;
+    }
+
+    private static APILedgerAssetIdentifier toAPILedgerIdentifier(@Nullable LedgerAssetIdentifier id) {
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = new APILedgerAssetIdentifierTypeCAIP19()
+                .assetIdentifierType(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19)
+                .network(id != null && id.network != null ? id.network : "")
+                .tokenId(id != null && id.tokenId != null ? id.tokenId : "")
+                .standard(id != null && id.standard != null ? id.standard : "");
+        return new APILedgerAssetIdentifier(caip19);
     }
 
     private static APITransactionDetails toAPI(@Nullable TransactionDetails details) {


### PR DESCRIPTION
## Bug

After the on-chain mint succeeds (Hedera HTS transfer SUCCESS), the FinP2P node rejects the `/api/assets/issue` response with code 999 `"unknown discriminator value: "` because the embedded asset's `ledgerIdentifier` serialized as null:

```json
"destination": {
  "asset": {
    "ledgerIdentifier": null,                                 ← rejects
    "resourceId": "org-a:102:..."
  },
  ...
}
```

`isCompleted: true` and `error: null`, so the adapter looks healthy — but the plan still fails because the response is unparseable.

## Root cause
Same shape as the PR #39 bug (CAIP-19 discriminator missing) but on a different emission path:
`Mappers.toAPIAsset(Asset)` set only `resourceId`. Affects every receipt response (issue / transfer / redeem / hold / release / rollback) and `GET /api/assets/receipts/{id}`.

## Fix
- `Mappers.toAPIAsset(Asset)` always emits a CAIP-19 wrapper.
- Fields sourced from `Asset.ledgerIdentifier` when populated (carried in by the request via `assetFromAPI`); empty strings when the adapter did not track the identifier.
- New `Mappers.toAPILedgerIdentifier(LedgerAssetIdentifier)` helper.

## Tests
- New `MappersReceiptResponseTest` (3 tests): receipt with full identifier, receipt without identifier (still emits discriminator), and `GET /api/assets/receipts/{id}` shape.
- `AbstractTokenLifecycleTest` gains an inline assertion on the issue-receipt's `destination.asset.ledgerIdentifier` carrying CAIP-19 end-to-end (Spring Boot + Postgres + HTTP).

## Status
✅ 42 tests pass (was 39, +3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)