### PR TITLE
Sample adapter: default schema = sample_adapter (concrete-adapter prefix)

### DIFF
--- a/sample-adapter/src/main/java/io/ownera/ledger/adapter/config/PostgresConfiguration.java
+++ b/sample-adapter/src/main/java/io/ownera/ledger/adapter/config/PostgresConfiguration.java
@@ -3,6 +3,8 @@ package io.ownera.ledger.adapter.config;
 import io.ownera.ledger.adapter.sample.db.DbLedger;
 import io.ownera.ledger.adapter.service.workflow.DbOperationStore;
 import io.ownera.ledger.adapter.service.*;
+import io.ownera.ledger.adapter.service.asset.AssetStore;
+import io.ownera.ledger.adapter.service.asset.DbAssetStore;
 import io.ownera.ledger.adapter.service.mapping.DbAccountMappingStore;
 import io.ownera.ledger.adapter.service.proof.ProofProvider;
 import io.ownera.ledger.adapter.service.workflow.OperationStore;
@@ -12,6 +14,7 @@ import org.jooq.SQLDialect;
 import org.jooq.impl.DSL;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -23,15 +26,24 @@ public class PostgresConfiguration {
 
     private static final Logger logger = LoggerFactory.getLogger(PostgresConfiguration.class);
 
+    /**
+     * Schema name for skeleton-owned tables. Driven by {@code LEDGER_SCHEMA} (operator override)
+     * with this adapter's hardcoded default {@code sample_adapter}. Real adapters substitute
+     * their own default (e.g. {@code hedera}, {@code canton}) so multiple adapter types coexist
+     * on a shared DB without colliding.
+     */
+    @Value("${ledger.schema:sample_adapter}")
+    private String ledgerSchema;
+
     @Bean
     public DSLContext dslContext(DataSource dataSource) {
         return DSL.using(dataSource, SQLDialect.POSTGRES);
     }
 
     @Bean
-    public DbLedger dbLedger(DSLContext dslContext, Optional<ProofProvider> proofProvider) {
-        logger.info("Initializing DbLedger with PostgreSQL backend (jOOQ)");
-        return new DbLedger(dslContext, proofProvider.orElse(null));
+    public DbLedger dbLedger(DSLContext dslContext, AssetStore assetStore, Optional<ProofProvider> proofProvider) {
+        logger.info("Initializing DbLedger with schema={}", ledgerSchema);
+        return new DbLedger(dslContext, ledgerSchema, assetStore, proofProvider.orElse(null));
     }
 
     @Bean
@@ -51,11 +63,16 @@ public class PostgresConfiguration {
 
     @Bean
     public OperationStore operationStore(DSLContext dslContext) {
-        return new DbOperationStore(dslContext);
+        return new DbOperationStore(dslContext, ledgerSchema);
     }
 
     @Bean
     public DbAccountMappingStore accountMappingStore(DSLContext dslContext) {
-        return new DbAccountMappingStore(dslContext);
+        return new DbAccountMappingStore(dslContext, ledgerSchema);
+    }
+
+    @Bean
+    public AssetStore assetStore(DSLContext dslContext) {
+        return new DbAssetStore(dslContext, ledgerSchema);
     }
 }

--- a/sample-adapter/src/main/java/io/ownera/ledger/adapter/sample/db/DbLedger.java
+++ b/sample-adapter/src/main/java/io/ownera/ledger/adapter/sample/db/DbLedger.java
@@ -3,6 +3,7 @@ package io.ownera.ledger.adapter.sample.db;
 import io.ownera.ledger.adapter.sample.HoldOperation;
 import io.ownera.ledger.adapter.sample.Transaction;
 import io.ownera.ledger.adapter.service.*;
+import io.ownera.ledger.adapter.service.asset.AssetStore;
 import io.ownera.ledger.adapter.service.model.*;
 import io.ownera.ledger.adapter.service.proof.ProofProvider;
 import org.jooq.DSLContext;
@@ -23,8 +24,14 @@ public class DbLedger implements TokenService, EscrowService, CommonService {
     private final @Nullable ProofProvider proofProvider;
 
     public DbLedger(DSLContext dsl, @Nullable ProofProvider proofProvider) {
+        this(dsl, "ledger_adapter", null, proofProvider);
+    }
+
+    public DbLedger(DSLContext dsl, String schemaName, @Nullable AssetStore assetStore, @Nullable ProofProvider proofProvider) {
         this.dsl = dsl;
-        this.storage = new DbStorage(dsl);
+        this.storage = assetStore != null
+                ? new DbStorage(dsl, assetStore)
+                : new DbStorage(dsl, schemaName);
         this.proofProvider = proofProvider;
     }
 

--- a/sample-adapter/src/main/resources/application.properties
+++ b/sample-adapter/src/main/resources/application.properties
@@ -17,5 +17,10 @@ spring.flyway.user=${MIGRATION_USERNAME:${DB_USERNAME}}
 spring.flyway.password=${MIGRATION_PASSWORD:${DB_PASSWORD}}
 spring.flyway.locations=classpath:db/migration/skeleton,classpath:db/migration/adapter
 spring.flyway.baseline-on-migrate=true
+# Schema name: each concrete adapter sets its own default (sample_adapter,
+# hedera, canton, …) so multiple adapter types coexist on a shared DB. Operators
+# override via LEDGER_SCHEMA when running two instances of the same adapter type
+# in the same namespace.
+ledger.schema=${LEDGER_SCHEMA:sample_adapter}
 spring.flyway.placeholders.ledger_user=${LEDGER_USER:${DB_USERNAME:}}
-spring.flyway.placeholders.schema_name=${LEDGER_SCHEMA:ledger_adapter}
+spring.flyway.placeholders.schema_name=${ledger.schema}

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/PostgresSchemaIsolationTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/PostgresSchemaIsolationTest.java
@@ -1,0 +1,61 @@
+package io.ownera.ledger.adapter.postgres;
+
+import io.ownera.ledger.adapter.PostgresContainerHolder;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Sanity check for the Node-skeleton-style schema-prefix convention: when each concrete
+ * adapter sets its own default ({@code sample_adapter} here, {@code hedera}/{@code canton}
+ * for real adapters), the legacy fallback {@code ledger_adapter} must NOT be created.
+ *
+ * Mirrors the Node PR #188 "custom schema name flows through migrations and queries" test.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PostgresSchemaIsolationTest {
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("DB_CONNECTION_STRING", PostgresContainerHolder.POSTGRES::getJdbcUrl);
+        registry.add("DB_USERNAME", PostgresContainerHolder.POSTGRES::getUsername);
+        registry.add("DB_PASSWORD", PostgresContainerHolder.POSTGRES::getPassword);
+    }
+
+    @Autowired
+    private DSLContext dsl;
+
+    @Test
+    void migrationsCreateSampleAdapterSchemaButNotLedgerAdapter() {
+        assertTrue(schemaExists("sample_adapter"),
+                "sample_adapter schema must exist (concrete-adapter prefix is the default)");
+        assertFalse(schemaExists("ledger_adapter"),
+                "ledger_adapter (legacy fallback) must NOT exist when an adapter prefix is configured");
+    }
+
+    @Test
+    void skeletonTablesLiveUnderTheConfiguredSchema() {
+        assertTrue(tableExists("sample_adapter", "operations"));
+        assertTrue(tableExists("sample_adapter", "assets"));
+        assertTrue(tableExists("sample_adapter", "account_mappings"));
+    }
+
+    private boolean schemaExists(String name) {
+        return dsl.fetchExists(
+                dsl.selectOne()
+                        .from("information_schema.schemata")
+                        .where("schema_name = ?", name));
+    }
+
+    private boolean tableExists(String schema, String table) {
+        return dsl.fetchExists(
+                dsl.selectOne()
+                        .from("information_schema.tables")
+                        .where("table_schema = ? AND table_name = ?", schema, table));
+    }
+}

--- a/sample-adapter/src/test/resources/application.properties
+++ b/sample-adapter/src/test/resources/application.properties
@@ -14,5 +14,6 @@ spring.flyway.user=${MIGRATION_USERNAME:${DB_USERNAME}}
 spring.flyway.password=${MIGRATION_PASSWORD:${DB_PASSWORD}}
 spring.flyway.locations=classpath:db/migration/skeleton,classpath:db/migration/adapter
 spring.flyway.baseline-on-migrate=true
+ledger.schema=${LEDGER_SCHEMA:sample_adapter}
 spring.flyway.placeholders.ledger_user=${LEDGER_USER:${DB_USERNAME:}}
-spring.flyway.placeholders.schema_name=${LEDGER_SCHEMA:ledger_adapter}
+spring.flyway.placeholders.schema_name=${ledger.schema}


### PR DESCRIPTION
## Why

Mirrors [finp2p-nodejs-skeleton-adapter PR #188](https://github.com/owneraio/finp2p-nodejs-skeleton-adapter/pull/188): each **concrete adapter** owns a hardcoded default schema name (\`sample_adapter\`, \`hedera\`, \`canton\`, …) so multiple **adapter types** can coexist on a shared database without colliding. Operators override via `LEDGER_SCHEMA` only when they need two instances of the **same** adapter type in the same namespace.

## What

- **Sample-adapter `application.properties`** (main + test): default schema is now `sample_adapter` (was `ledger_adapter`). `LEDGER_SCHEMA` env var still wins when set.
- **New `ledger.schema` Spring property** feeds both the Flyway placeholder and all skeleton-side stores. `PostgresConfiguration` injects `@Value("${ledger.schema:sample_adapter}")` and wires it into:
  - `DbOperationStore(dsl, ledgerSchema)`
  - `DbAccountMappingStore(dsl, ledgerSchema)`
  - `DbAssetStore(dsl, ledgerSchema)`
  - `DbLedger(dsl, ledgerSchema, assetStore, proofProvider)` (new constructor; legacy 2-arg preserved)
- **New `PostgresSchemaIsolationTest`** asserts:
  - `sample_adapter` schema exists
  - `ledger_adapter` (legacy default) does **not** exist
  - all three skeleton tables (`operations`, `assets`, `account_mappings`) live under `sample_adapter`

The skeleton's `Db*Store` fallback to `"ledger_adapter"` is preserved for backward compatibility — only the sample-adapter wiring changes.

## Status
✅ 44 tests pass (was 42, +2 isolation tests). The whole suite now exercises the configurability path against `sample_adapter`, not `ledger_adapter`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)