### PR TITLE
PR 0: workflow correctness fix — persist outputs JSONB

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/PostgresWorkflowOutputsTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/PostgresWorkflowOutputsTest.java
@@ -5,7 +5,12 @@ import io.ownera.ledger.adapter.PostgresContainerHolder;
 import io.ownera.ledger.adapter.api.model.APILedgerAssetIdentifierTypeCAIP19;
 import io.ownera.ledger.adapter.api.model.APIOperationStatus;
 import io.ownera.ledger.adapter.api.model.APIOperationStatusCreateAsset;
+import io.ownera.ledger.adapter.service.model.AssetCreationStatus;
+import io.ownera.ledger.adapter.service.model.OperationMetadata;
+import io.ownera.ledger.adapter.service.model.PendingAssetCreation;
+import io.ownera.ledger.adapter.service.model.PollingResponseStrategy;
 import io.ownera.ledger.adapter.service.workflow.DbOperationStore;
+import io.ownera.ledger.adapter.service.workflow.OperationExecutor;
 import io.ownera.ledger.adapter.service.workflow.OperationRecord;
 import io.ownera.ledger.adapter.service.workflow.OperationStore;
 import org.jooq.DSLContext;
@@ -135,6 +140,77 @@ public class PostgresWorkflowOutputsTest {
                 "/api/operations/status/does-not-exist-" + System.nanoTime(),
                 String.class);
         assertEquals(404, resp.getStatusCodeValue());
+    }
+
+    @Test
+    void pollingEndpointReturnsPersistedPendingPayloadForInProgressOperation() {
+        // Async workflow contract: every known cid must be pollable. The executor persists a
+        // pending payload on insertion so the polling endpoint returns 200 with isCompleted=false,
+        // not 404. Drive execute() with an async executor so it returns immediately after save.
+        OperationExecutor executor = new OperationExecutor(store, null, true);
+        // Block the work supplier until we have polled the endpoint, so the row stays IN_PROGRESS.
+        java.util.concurrent.CountDownLatch hold = new java.util.concurrent.CountDownLatch(1);
+        String inputsHash = "hash-pending-" + System.nanoTime();
+        AssetCreationStatus pending = executor.execute(
+                "createAsset", inputsHash,
+                () -> {
+                    try { hold.await(); } catch (InterruptedException ignored) {}
+                    throw new RuntimeException("must not finalize before polling");
+                },
+                cid -> new PendingAssetCreation(cid, new OperationMetadata(new PollingResponseStrategy()))
+        );
+        try {
+            assertTrue(pending instanceof PendingAssetCreation, "execute() must return pending in async mode");
+            String cid = ((PendingAssetCreation) pending).correlationId;
+
+            ResponseEntity<APIOperationStatus> resp = restTemplate.getForEntity(
+                    "/api/operations/status/" + cid, APIOperationStatus.class);
+            assertEquals(200, resp.getStatusCodeValue(),
+                    "in-progress cid must be pollable, not 404 — see Node createServiceProxy");
+            APIOperationStatus body = resp.getBody();
+            assertNotNull(body);
+            APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset) body.getActualInstance();
+            assertEquals(APIOperationStatusCreateAsset.TypeEnum.CREATEASSET, wrap.getType());
+            assertFalse(wrap.getOperation().getIsCompleted(),
+                    "pending payload must report isCompleted=false");
+        } finally {
+            hold.countDown();
+        }
+    }
+
+    @Test
+    void pollingEndpointReturnsPersistedFailurePayloadForFailedOperation() {
+        // Failure branch of the same contract: the executor must persist a failure payload so
+        // failed operations are pollable as completed-with-error, not indistinguishable from
+        // unknown cids (which 404).
+        OperationExecutor executor = new OperationExecutor(store, null, false);
+        String inputsHash = "hash-failure-" + System.nanoTime();
+        RuntimeException boom = new RuntimeException("simulated workflow failure");
+        try {
+            executor.execute(
+                    "createAsset", inputsHash,
+                    () -> { throw boom; },
+                    cid -> new PendingAssetCreation(cid, new OperationMetadata(new PollingResponseStrategy()))
+            );
+            fail("execute() must rethrow in sync mode");
+        } catch (RuntimeException e) {
+            assertSame(boom, e);
+        }
+
+        OperationRecord rec = store.findByInputsHash(inputsHash);
+        assertNotNull(rec);
+        assertEquals(OperationRecord.Status.FAILED, rec.status);
+
+        ResponseEntity<APIOperationStatus> resp = restTemplate.getForEntity(
+                "/api/operations/status/" + rec.cid, APIOperationStatus.class);
+        assertEquals(200, resp.getStatusCodeValue(),
+                "failed cid must be pollable as completed-with-error, not 404");
+        APIOperationStatus body = resp.getBody();
+        assertNotNull(body);
+        APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset) body.getActualInstance();
+        assertTrue(wrap.getOperation().getIsCompleted(),
+                "failure payload must report isCompleted=true");
+        assertNotNull(wrap.getOperation().getError(), "failure payload must carry error details");
     }
 
     @Test

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/PostgresWorkflowOutputsTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/PostgresWorkflowOutputsTest.java
@@ -1,0 +1,210 @@
+package io.ownera.ledger.adapter.postgres;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ownera.ledger.adapter.PostgresContainerHolder;
+import io.ownera.ledger.adapter.api.model.APILedgerAssetIdentifierTypeCAIP19;
+import io.ownera.ledger.adapter.api.model.APIOperationStatus;
+import io.ownera.ledger.adapter.api.model.APIOperationStatusCreateAsset;
+import io.ownera.ledger.adapter.service.workflow.DbOperationStore;
+import io.ownera.ledger.adapter.service.workflow.OperationRecord;
+import io.ownera.ledger.adapter.service.workflow.OperationStore;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Regression tests for the V1003 workflow-correctness fix.
+ *
+ * <p>Before V1003, {@code DbOperationStore.updateStatus(...)} silently dropped its
+ * {@code OperationStatus} argument and {@code toRecord(...)} always rebuilt with
+ * {@code result == null}. {@code GET /api/operations/status/{cid}} therefore could not
+ * return the actual operation result — it delegated to {@code CommonService.operationStatus}
+ * on the underlying adapter, which looks up by transaction id (wrong key for cid lookups)
+ * and threw.
+ *
+ * <p>After V1003: the {@code outputs JSONB} column persists the serialized
+ * {@link APIOperationStatus} produced by {@code Mappers.toAPI} at completion time, and the
+ * polling endpoint reads that JSON directly — mirroring the Node skeleton's
+ * {@code createServiceProxy} which returns {@code operation.outputs} verbatim
+ * (see {@code finp2p-nodejs-skeleton-adapter/skeleton/src/workflows/service.ts}).
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class PostgresWorkflowOutputsTest {
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("DB_CONNECTION_STRING", PostgresContainerHolder.POSTGRES::getJdbcUrl);
+        registry.add("DB_USERNAME", PostgresContainerHolder.POSTGRES::getUsername);
+        registry.add("DB_PASSWORD", PostgresContainerHolder.POSTGRES::getPassword);
+    }
+
+    @Autowired
+    private DSLContext dsl;
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    private OperationStore store;
+
+    @BeforeEach
+    void setup() {
+        store = new DbOperationStore(dsl, "sample_adapter");
+    }
+
+    @Test
+    void storeRoundTripsOutputsJson() throws Exception {
+        String cid = "test-cid-roundtrip-" + System.nanoTime();
+        store.save(new OperationRecord(cid, "createAsset", OperationRecord.Status.IN_PROGRESS,
+                "hash-" + cid, null));
+
+        // Before V1003 this call silently dropped the second argument.
+        String outputs = "{\"type\":\"createAsset\",\"operation\":{\"cid\":\"\",\"isCompleted\":true}}";
+        store.updateStatus(cid, OperationRecord.Status.COMPLETED, outputs);
+
+        // Postgres JSONB normalizes whitespace; compare parsed trees, not byte-for-byte.
+        ObjectMapper mapper = new ObjectMapper();
+        assertEquals(mapper.readTree(outputs), mapper.readTree(store.findOutputsByCid(cid)),
+                "outputs JSON must round-trip through the store");
+    }
+
+    @Test
+    void findOutputsByCidReturnsNullForUnknownCid() {
+        assertNull(store.findOutputsByCid("does-not-exist-" + System.nanoTime()));
+    }
+
+    @Test
+    void findOutputsByCidReturnsNullForInProgressOperation() {
+        String cid = "test-cid-inprogress-" + System.nanoTime();
+        store.save(new OperationRecord(cid, "issue", OperationRecord.Status.IN_PROGRESS,
+                "hash-" + cid, null));
+        // No updateStatus call → outputs column stays null.
+        assertNull(store.findOutputsByCid(cid),
+                "in-progress operation must not surface fake outputs");
+    }
+
+    @Test
+    void pollingEndpointReturnsPersistedOutputsVerbatim() {
+        // Stage a completed operation directly in the store so we can exercise the
+        // polling endpoint end-to-end. (The sample sync executor completes inline
+        // and the client never sees a cid; PR 1's async workflow will be the
+        // production path that drives this endpoint.)
+        String cid = "test-cid-polling-" + System.nanoTime();
+        store.save(new OperationRecord(cid, "createAsset", OperationRecord.Status.IN_PROGRESS,
+                "hash-" + cid, null));
+        String outputs = "{"
+                + "\"type\":\"createAsset\","
+                + "\"operation\":{"
+                + "\"cid\":\"\","
+                + "\"isCompleted\":true,"
+                + "\"response\":{\"ledgerAssetInfo\":{\"ledgerIdentifier\":{"
+                + "\"assetIdentifierType\":\"CAIP-19\","
+                + "\"network\":\"hedera:testnet\","
+                + "\"tokenId\":\"0.0.123456\","
+                + "\"standard\":\"HTS\""
+                + "}}}"
+                + "}"
+                + "}";
+        store.updateStatus(cid, OperationRecord.Status.COMPLETED, outputs);
+
+        ResponseEntity<APIOperationStatus> resp = restTemplate.getForEntity(
+                "/api/operations/status/" + cid, APIOperationStatus.class);
+        assertEquals(200, resp.getStatusCodeValue());
+        APIOperationStatus body = resp.getBody();
+        assertNotNull(body);
+        APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset) body.getActualInstance();
+        assertEquals(APIOperationStatusCreateAsset.TypeEnum.CREATEASSET, wrap.getType());
+        assertTrue(wrap.getOperation().getIsCompleted());
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = (APILedgerAssetIdentifierTypeCAIP19)
+                wrap.getOperation().getResponse().getLedgerAssetInfo()
+                        .getLedgerIdentifier().getActualInstance();
+        assertEquals(APILedgerAssetIdentifierTypeCAIP19.AssetIdentifierTypeEnum.CAIP_19,
+                caip19.getAssetIdentifierType());
+        assertEquals("0.0.123456", caip19.getTokenId());
+    }
+
+    @Test
+    void pollingEndpointReturns404ForUnknownCid() {
+        ResponseEntity<String> resp = restTemplate.getForEntity(
+                "/api/operations/status/does-not-exist-" + System.nanoTime(),
+                String.class);
+        assertEquals(404, resp.getStatusCodeValue());
+    }
+
+    @Test
+    void findByInputsHashPopulatesResultFromStoredOutputs() {
+        // The bug the reviewer flagged on PR 0: toRecord() always rebuilt with
+        // result=null, so OperationExecutor.execute's cache-hit branch
+        // (existing.result != null) could never fire. The fix populates result
+        // by parsing the persisted outputs JSON via Mappers.fromAPI.
+        String cid = "test-cid-replay-" + System.nanoTime();
+        String inputsHash = "hash-" + cid;
+        store.save(new OperationRecord(cid, "createAsset", OperationRecord.Status.IN_PROGRESS,
+                inputsHash, null));
+
+        // Persist a completed createAsset payload with a CAIP-19 ledgerIdentifier.
+        String outputs = "{"
+                + "\"type\":\"createAsset\","
+                + "\"operation\":{"
+                + "\"cid\":\"\","
+                + "\"isCompleted\":true,"
+                + "\"response\":{\"ledgerAssetInfo\":{\"ledgerIdentifier\":{"
+                + "\"assetIdentifierType\":\"CAIP-19\","
+                + "\"network\":\"hedera:testnet\","
+                + "\"tokenId\":\"0.0.999999\","
+                + "\"standard\":\"HTS\""
+                + "}}}"
+                + "}"
+                + "}";
+        store.updateStatus(cid, OperationRecord.Status.COMPLETED, outputs);
+
+        OperationRecord found = store.findByInputsHash(inputsHash);
+        assertNotNull(found, "record must be found by inputs hash");
+        assertEquals(OperationRecord.Status.COMPLETED, found.status);
+        assertNotNull(found.result,
+                "result must be reconstructed from persisted outputs — this is the "
+                        + "cache-hit fix; without it the executor falls through to Pending");
+        // Verify the reconstructed result is the right concrete type and carries the tokenId.
+        assertTrue(found.result instanceof io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation,
+                "expected SuccessfulAssetCreation, got " + found.result.getClass().getName());
+        io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation success =
+                (io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation) found.result;
+        assertEquals("0.0.999999", success.result.tokenId,
+                "tokenId must survive the JSONB round-trip");
+    }
+
+    @Test
+    void findByCidPopulatesResultFromStoredOutputs() {
+        // Same fix for the cid-keyed lookup used by other consumers.
+        String cid = "test-cid-replay-cid-" + System.nanoTime();
+        store.save(new OperationRecord(cid, "createAsset", OperationRecord.Status.IN_PROGRESS,
+                "hash-" + cid, null));
+        String outputs = "{"
+                + "\"type\":\"createAsset\","
+                + "\"operation\":{"
+                + "\"cid\":\"\","
+                + "\"isCompleted\":true,"
+                + "\"response\":{\"ledgerAssetInfo\":{\"ledgerIdentifier\":{"
+                + "\"assetIdentifierType\":\"CAIP-19\","
+                + "\"network\":\"hedera:testnet\","
+                + "\"tokenId\":\"0.0.42\","
+                + "\"standard\":\"HTS\""
+                + "}}}"
+                + "}"
+                + "}";
+        store.updateStatus(cid, OperationRecord.Status.COMPLETED, outputs);
+
+        OperationRecord found = store.findByCid(cid);
+        assertNotNull(found);
+        assertNotNull(found.result, "findByCid must also populate result from outputs");
+        io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation success =
+                (io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation) found.result;
+        assertEquals("0.0.42", success.result.tokenId);
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
@@ -1,10 +1,12 @@
 package io.ownera.ledger.adapter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.ownera.ledger.adapter.api.model.*;
 import io.ownera.ledger.adapter.service.*;
 import io.ownera.ledger.adapter.service.model.*;
 import io.ownera.ledger.adapter.service.workflow.CorrelationIdGenerator;
 import io.ownera.ledger.adapter.service.workflow.OperationExecutor;
+import io.ownera.ledger.adapter.service.workflow.OperationStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
@@ -29,11 +31,14 @@ public class Controller {
     private final SignatureVerifier signatureVerifier;
     private final OperationExecutor operationExecutor;
     private final Optional<TransactionHook> transactionHook;
+    private final OperationStore operationStore;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     public Controller(EscrowService escrowService, TokenService tokenService, PaymentService paymentService,
                       PlanApprovalService planApprovalService, CommonService commonService,
                       HealthService healthService, SignatureVerifier signatureVerifier,
-                      OperationExecutor operationExecutor, Optional<TransactionHook> transactionHook) {
+                      OperationExecutor operationExecutor, Optional<TransactionHook> transactionHook,
+                      OperationStore operationStore) {
         this.escrowService = escrowService;
         this.tokenService = tokenService;
         this.paymentService = paymentService;
@@ -43,6 +48,7 @@ public class Controller {
         this.signatureVerifier = signatureVerifier;
         this.operationExecutor = operationExecutor;
         this.transactionHook = transactionHook;
+        this.operationStore = operationStore;
     }
 
     private final static Logger logger = LoggerFactory.getLogger(Controller.class);
@@ -309,8 +315,22 @@ public class Controller {
 
     @GetMapping(value = "/api/operations/status/{id}")
     public final ResponseEntity<APIOperationStatus> getOperationStatus(@PathVariable("id") String correlationId) {
-        OperationStatus status = commonService.operationStatus(correlationId);
-        return ResponseEntity.status(HttpStatus.OK).body(toAPI(status));
+        // Operations table is the source of truth for cid lookups (matches the Node
+        // workflow proxy in skeleton/src/workflows/service.ts: createServiceProxy
+        // returns operation.outputs directly). Reading outputs verbatim is the only
+        // correct path — CommonService.operationStatus on the underlying adapter
+        // looks up by transaction id, not by cid, so it is never appropriate here.
+        String stored = operationStore.findOutputsByCid(correlationId);
+        if (stored == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+        try {
+            APIOperationStatus api = objectMapper.readValue(stored, APIOperationStatus.class);
+            return ResponseEntity.status(HttpStatus.OK).body(api);
+        } catch (Exception e) {
+            logger.error("Failed to parse persisted outputs for cid={}: {}", correlationId, e.getMessage());
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+        }
     }
 
     // --- Escrow endpoints ---

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -957,4 +957,167 @@ public class Mappers {
                 .network(result.reference != null && result.reference.network != null ? result.reference.network : "")
                 .standard(result.reference != null && result.reference.tokenStandard != null ? result.reference.tokenStandard : "");
     }
+
+    // --- Inverse mappers (APIOperationStatus → internal OperationStatus) ---
+    // Used by DbOperationStore.toRecord to populate the in-memory record's `result` field
+    // from the persisted outputs JSONB, so OperationExecutor's idempotent-replay cache-hit
+    // path returns the original completed payload (not a stale Pending).
+    //
+    // Internal reconstructions are intentionally minimal: they preserve only the fields
+    // that toAPI(...) reads, so toAPI(fromAPI(x)) is a faithful round-trip for the
+    // controller response path. Fields like ReceiptOperation's proof, deposit details, or
+    // OperationMetadata that don't round-trip cleanly are dropped.
+
+    public static OperationStatus fromAPI(APIOperationStatus status) {
+        Object actual = status.getActualInstance();
+        if (actual instanceof APIOperationStatusCreateAsset) {
+            return fromAPI(((APIOperationStatusCreateAsset) actual).getOperation());
+        }
+        if (actual instanceof APIOperationStatusReceipt) {
+            return fromAPI(((APIOperationStatusReceipt) actual).getOperation());
+        }
+        if (actual instanceof APIOperationStatusDeposit) {
+            return fromAPI(((APIOperationStatusDeposit) actual).getOperation());
+        }
+        if (actual instanceof APIOperationStatusApproval) {
+            return fromAPI(((APIOperationStatusApproval) actual).getOperation());
+        }
+        throw new MappingException("Unsupported operation status variant: " + actual.getClass().getName());
+    }
+
+    public static AssetCreationStatus fromAPI(APICreateAssetOperation op) {
+        if (!Boolean.TRUE.equals(op.getIsCompleted())) {
+            return new PendingAssetCreation(op.getCid() != null ? op.getCid() : "", null);
+        }
+        if (op.getError() != null) {
+            return new FailedAssetCreation(toErrorDetails(op.getError().getCode(), op.getError().getMessage()));
+        }
+        APIAssetCreateResponse resp = op.getResponse();
+        if (resp == null) {
+            throw new MappingException("APICreateAssetOperation is completed but has no error and no response");
+        }
+        String tokenId = "";
+        if (resp.getLedgerAssetInfo() != null && resp.getLedgerAssetInfo().getLedgerIdentifier() != null) {
+            Object id = resp.getLedgerAssetInfo().getLedgerIdentifier().getActualInstance();
+            if (id instanceof APILedgerAssetIdentifierTypeCAIP19) {
+                APILedgerAssetIdentifierTypeCAIP19 caip = (APILedgerAssetIdentifierTypeCAIP19) id;
+                tokenId = caip.getTokenId() != null ? caip.getTokenId() : "";
+            }
+        }
+        return new SuccessfulAssetCreation(new AssetCreationResult(tokenId, null));
+    }
+
+    public static PlanApprovalStatus fromAPI(APIExecutionPlanApprovalOperation op) {
+        if (!Boolean.TRUE.equals(op.getIsCompleted())) {
+            return new PendingPlan(op.getCid() != null ? op.getCid() : "", null);
+        }
+        APIPlanApprovalResponseApproval approval = op.getApproval();
+        if (approval != null) {
+            Object actual = approval.getActualInstance();
+            if (actual instanceof APIPlanRejected) {
+                APIPlanRejected rejected = (APIPlanRejected) actual;
+                if (rejected.getFailure() != null) {
+                    Object failureActual = rejected.getFailure().getActualInstance();
+                    if (failureActual instanceof APIValidationFailure) {
+                        APIValidationFailure vf = (APIValidationFailure) failureActual;
+                        return new RejectedPlan(toErrorDetails(vf.getCode(), vf.getMessage()));
+                    }
+                }
+                return new RejectedPlan(new ErrorDetails(0, "rejected"));
+            }
+            if (actual instanceof APIPlanApproved) {
+                return new ApprovedPlan();
+            }
+        }
+        return new ApprovedPlan();
+    }
+
+    public static DepositOperation fromAPI(APIDepositOperation op) {
+        if (!Boolean.TRUE.equals(op.getIsCompleted())) {
+            return new PendingDepositOperation(op.getCid() != null ? op.getCid() : "", null);
+        }
+        if (op.getError() != null) {
+            // APIDepositOperation.error is typed as Object in the generated model; after
+            // Jackson roundtrip it's a Map<String, Object> with code/message keys.
+            return new FailedDepositOperation(toErrorDetailsFromObject(op.getError()));
+        }
+        APIDepositInstruction resp = op.getResponse();
+        if (resp == null) {
+            throw new MappingException("APIDepositOperation is completed but has no error and no response");
+        }
+        DepositInstruction instr = new DepositInstruction(
+                null, // destination not roundtripped; toAPI doesn't read it back
+                resp.getDescription(),
+                java.util.Collections.emptyList(), // paymentOptions reconstruction not needed for round-trip
+                resp.getOperationId(),
+                resp.getDetails());
+        return new SuccessfulDepositOperation(instr);
+    }
+
+    public static ReceiptOperation fromAPI(APIReceiptOperation op) {
+        if (!Boolean.TRUE.equals(op.getIsCompleted())) {
+            return new PendingReceiptStatus(op.getCid() != null ? op.getCid() : "", null);
+        }
+        if (op.getError() != null) {
+            return new FailedReceiptStatus(toErrorDetails(op.getError().getCode(), op.getError().getMessage()));
+        }
+        APIReceipt apiReceipt = op.getResponse();
+        if (apiReceipt == null) {
+            throw new MappingException("APIReceiptOperation is completed but has no error and no response");
+        }
+        Source source = apiReceipt.getSource() != null ? sourceFromAPI(apiReceipt.getSource()) : null;
+        Destination destination = apiReceipt.getDestination() != null ? destinationFromAPI(apiReceipt.getDestination()) : null;
+        // Asset is embedded in source/destination (APIAccount-shaped); both carry the same one.
+        Asset asset = null;
+        if (apiReceipt.getDestination() != null && apiReceipt.getDestination().getAsset() != null) {
+            asset = fromAPI(apiReceipt.getDestination().getAsset());
+        } else if (apiReceipt.getSource() != null && apiReceipt.getSource().getAsset() != null) {
+            asset = fromAPI(apiReceipt.getSource().getAsset());
+        }
+        OperationType opType = apiReceipt.getOperationType() != null
+                ? toInternalOperationType(apiReceipt.getOperationType()) : OperationType.TRANSFER;
+        TransactionDetails txDetails = apiReceipt.getTransactionDetails() != null
+                ? new TransactionDetails(
+                        apiReceipt.getTransactionDetails().getTransactionId(),
+                        apiReceipt.getTransactionDetails().getOperationId())
+                : null;
+        TradeDetails tradeDetails = null;
+        if (apiReceipt.getTradeDetails() != null && apiReceipt.getTradeDetails().getExecutionContext() != null) {
+            APIReceiptExecutionContext exCtx = apiReceipt.getTradeDetails().getExecutionContext();
+            tradeDetails = new TradeDetails(new ExecutionContext(exCtx.getExecutionPlanId(), 0));
+        }
+        long timestamp = apiReceipt.getTimestamp() != null ? apiReceipt.getTimestamp() : 0L;
+        Receipt receipt = new Receipt(
+                apiReceipt.getId(), opType, asset, source, destination,
+                apiReceipt.getQuantity(), txDetails, tradeDetails, null, timestamp);
+        return new SuccessReceiptStatus(receipt);
+    }
+
+    private static ErrorDetails toErrorDetails(@Nullable Integer code, @Nullable String message) {
+        return new ErrorDetails(code != null ? code : 0, message != null ? message : "");
+    }
+
+    @SuppressWarnings("unchecked")
+    private static ErrorDetails toErrorDetailsFromObject(Object error) {
+        if (error instanceof Map) {
+            Map<String, Object> map = (Map<String, Object>) error;
+            Object code = map.get("code");
+            Object message = map.get("message");
+            int codeInt = code instanceof Number ? ((Number) code).intValue() : 0;
+            return new ErrorDetails(codeInt, message != null ? message.toString() : "");
+        }
+        return new ErrorDetails(0, error != null ? error.toString() : "");
+    }
+
+    private static OperationType toInternalOperationType(APIOperationType apiType) {
+        switch (apiType) {
+            case ISSUE:    return OperationType.ISSUE;
+            case TRANSFER: return OperationType.TRANSFER;
+            case REDEEM:   return OperationType.REDEEM;
+            case HOLD:     return OperationType.HOLD;
+            case RELEASE:  return OperationType.RELEASE;
+            default:
+                throw new MappingException("Unsupported APIOperationType: " + apiType);
+        }
+    }
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
@@ -55,13 +55,16 @@ public class DbOperationStore implements OperationStore {
     }
 
     @Override
-    public void save(OperationRecord record) {
-        dsl.insertInto(table)
+    public void save(OperationRecord record, @Nullable String pendingOutputsJson) {
+        var insert = dsl.insertInto(table)
                 .set(CID, record.cid)
                 .set(METHOD, record.method)
                 .set(STATUS, record.status.name())
-                .set(INPUTS_HASH, record.inputsHash)
-                .execute();
+                .set(INPUTS_HASH, record.inputsHash);
+        if (pendingOutputsJson != null) {
+            insert = insert.set(OUTPUTS, JSONB.valueOf(pendingOutputsJson));
+        }
+        insert.execute();
     }
 
     @Override

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
@@ -1,10 +1,17 @@
 package io.ownera.ledger.adapter.service.workflow;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ownera.ledger.adapter.Mappers;
+import io.ownera.ledger.adapter.api.model.APIOperationStatus;
 import io.ownera.ledger.adapter.service.model.OperationStatus;
 import org.jooq.DSLContext;
 import org.jooq.Field;
+import org.jooq.JSONB;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
+import org.jooq.impl.SQLDataType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
 
@@ -15,10 +22,15 @@ import javax.annotation.Nullable;
  */
 public class DbOperationStore implements OperationStore {
 
+    private static final Logger logger = LoggerFactory.getLogger(DbOperationStore.class);
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
     private static final Field<String> CID = DSL.field(DSL.name("cid"), String.class);
     private static final Field<String> METHOD = DSL.field(DSL.name("method"), String.class);
     private static final Field<String> STATUS = DSL.field(DSL.name("status"), String.class);
     private static final Field<String> INPUTS_HASH = DSL.field(DSL.name("inputs_hash"), String.class);
+    private static final Field<JSONB> INPUTS  = DSL.field(DSL.name("inputs"),  SQLDataType.JSONB);
+    private static final Field<JSONB> OUTPUTS = DSL.field(DSL.name("outputs"), SQLDataType.JSONB);
 
     private final DSLContext dsl;
     private final Table<?> table;
@@ -53,11 +65,19 @@ public class DbOperationStore implements OperationStore {
     }
 
     @Override
-    public void updateStatus(String cid, OperationRecord.Status status, @Nullable OperationStatus result) {
-        dsl.update(table)
-                .set(STATUS, status.name())
-                .where(CID.eq(cid))
-                .execute();
+    public void updateStatus(String cid, OperationRecord.Status status, @Nullable String outputsJson) {
+        if (outputsJson != null) {
+            dsl.update(table)
+                    .set(STATUS, status.name())
+                    .set(OUTPUTS, JSONB.valueOf(outputsJson))
+                    .where(CID.eq(cid))
+                    .execute();
+        } else {
+            dsl.update(table)
+                    .set(STATUS, status.name())
+                    .where(CID.eq(cid))
+                    .execute();
+        }
     }
 
     @Override
@@ -70,13 +90,39 @@ public class DbOperationStore implements OperationStore {
                 .orElse(null);
     }
 
+    @Override
+    @Nullable
+    public String findOutputsByCid(String cid) {
+        JSONB row = dsl.select(OUTPUTS)
+                .from(table)
+                .where(CID.eq(cid))
+                .fetchOne(OUTPUTS);
+        return row != null ? row.data() : null;
+    }
+
     private OperationRecord toRecord(org.jooq.Record r) {
+        // Parse the persisted outputs JSON back into an internal OperationStatus so the
+        // idempotent-replay cache-hit path in OperationExecutor.execute can return the
+        // original completed payload (instead of falling through to Pending). Mirrors
+        // Node's createServiceProxy → "if (!inserted) return storageOperation.outputs"
+        // (skeleton/src/workflows/service.ts). Best-effort: a parse failure is logged but
+        // does not break record lookup — execute() simply falls back to Pending.
+        OperationStatus result = null;
+        JSONB outputs = r.get(OUTPUTS);
+        if (outputs != null && outputs.data() != null && !outputs.data().isEmpty()) {
+            try {
+                APIOperationStatus api = MAPPER.readValue(outputs.data(), APIOperationStatus.class);
+                result = Mappers.fromAPI(api);
+            } catch (Exception e) {
+                logger.warn("Failed to parse persisted outputs for cid={}: {}", r.get(CID), e.getMessage());
+            }
+        }
         return new OperationRecord(
                 r.get(CID),
                 r.get(METHOD),
                 OperationRecord.Status.valueOf(r.get(STATUS)),
                 r.get(INPUTS_HASH),
-                null
+                result
         );
     }
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationExecutor.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationExecutor.java
@@ -20,14 +20,23 @@ public class OperationExecutor {
     private final @Nullable CallbackClient callbackClient;
     private final boolean async;
     private final @Nullable ExecutorService executorPool;
+    private final OperationOutputSerializer outputSerializer;
 
     public OperationExecutor(OperationStore store,
                              @Nullable CallbackClient callbackClient,
                              boolean async) {
+        this(store, callbackClient, async, OperationOutputSerializer.defaultSerializer());
+    }
+
+    public OperationExecutor(OperationStore store,
+                             @Nullable CallbackClient callbackClient,
+                             boolean async,
+                             OperationOutputSerializer outputSerializer) {
         this.store = store;
         this.callbackClient = callbackClient;
         this.async = async;
         this.executorPool = async ? Executors.newCachedThreadPool() : null;
+        this.outputSerializer = outputSerializer;
     }
 
     /**
@@ -72,7 +81,8 @@ public class OperationExecutor {
                 logger.debug("Returning cached result for method={}, cid={}", method, existing.cid);
                 return (T) existing.result;
             }
-            logger.debug("Operation in progress for method={}, cid={}", method, existing.cid);
+            logger.debug("Operation in progress or completed (cached outputs only durable via polling) "
+                    + "for method={}, cid={}", method, existing.cid);
             return pendingFactory.createPending(existing.cid);
         }
 
@@ -92,7 +102,8 @@ public class OperationExecutor {
     private <T extends OperationStatus> T executeOperation(String cid, String method, Supplier<T> operation) {
         try {
             T result = operation.get();
-            store.updateStatus(cid, OperationRecord.Status.COMPLETED, result);
+            String outputsJson = trySerialize(cid, method, result);
+            store.updateStatus(cid, OperationRecord.Status.COMPLETED, outputsJson);
 
             if (callbackClient != null) {
                 try {
@@ -105,8 +116,19 @@ public class OperationExecutor {
             return result;
         } catch (Exception e) {
             logger.error("Operation failed: method={}, cid={}, error={}", method, cid, e.getMessage());
-            store.updateStatus(cid, OperationRecord.Status.FAILED, null);
+            store.updateStatus(cid, OperationRecord.Status.FAILED, (String) null);
             if (!async) throw e;
+            return null;
+        }
+    }
+
+    private String trySerialize(String cid, String method, OperationStatus result) {
+        try {
+            return outputSerializer.serialize(result);
+        } catch (Exception e) {
+            // Outputs are an optimization for polling/replay — never block the operation's
+            // completion on a serialization failure. Log and persist with null outputs.
+            logger.warn("Failed to serialize outputs for method={}, cid={}: {}", method, cid, e.getMessage());
             return null;
         }
     }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationExecutor.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationExecutor.java
@@ -89,11 +89,16 @@ public class OperationExecutor {
         String cid = CorrelationIdGenerator.generate();
         OperationRecord record = new OperationRecord(
                 cid, method, OperationRecord.Status.IN_PROGRESS, inputsHash, null);
-        store.save(record);
+        // Persist a pending payload on insertion so polling returns an in-progress response
+        // for the cid instead of 404 — matches Node's createServiceProxy contract where every
+        // known cid is pollable (skeleton/src/workflows/service.ts).
+        T pending = pendingFactory.createPending(cid);
+        String pendingJson = trySerialize(cid, method, pending);
+        store.save(record, pendingJson);
 
         if (async) {
             executorPool.submit(() -> executeOperation(cid, method, operation));
-            return pendingFactory.createPending(cid);
+            return pending;
         }
 
         return executeOperation(cid, method, operation);
@@ -116,8 +121,22 @@ public class OperationExecutor {
             return result;
         } catch (Exception e) {
             logger.error("Operation failed: method={}, cid={}, error={}", method, cid, e.getMessage());
-            store.updateStatus(cid, OperationRecord.Status.FAILED, (String) null);
+            // Persist a failure payload so polling returns a proper failed-operation response
+            // (matches Node's wrappedResponse error branch in service.ts). Polling reserves 404
+            // for truly unknown cids.
+            String failureJson = tryBuildFailure(cid, method, e);
+            store.updateStatus(cid, OperationRecord.Status.FAILED, failureJson);
             if (!async) throw e;
+            return null;
+        }
+    }
+
+    private String tryBuildFailure(String cid, String method, Exception cause) {
+        try {
+            OperationStatus failure = WorkflowOutcomes.failureFor(method, 1, String.valueOf(cause.getMessage()));
+            return outputSerializer.serialize(failure);
+        } catch (Exception e) {
+            logger.warn("Failed to build/serialize failure payload for method={}, cid={}: {}", method, cid, e.getMessage());
             return null;
         }
     }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationOutputSerializer.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationOutputSerializer.java
@@ -1,0 +1,46 @@
+package io.ownera.ledger.adapter.service.workflow;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ownera.ledger.adapter.Mappers;
+import io.ownera.ledger.adapter.api.model.APIOperationStatus;
+import io.ownera.ledger.adapter.service.model.OperationStatus;
+
+/**
+ * Serializes an internal {@link OperationStatus} into the wire-format JSON
+ * (an {@link APIOperationStatus}) for durable storage in
+ * {@code operations.outputs}.
+ *
+ * <p>The default implementation goes through {@link Mappers#toAPI(OperationStatus)}
+ * so persisted outputs are byte-identical to what the controller returns from
+ * {@code GET /api/operations/status/{cid}} — the polling endpoint can serve the
+ * stored JSON directly without round-tripping.
+ *
+ * <p>Tests / custom executors may inject a different serializer to control
+ * format or fail-fast behavior.
+ */
+@FunctionalInterface
+public interface OperationOutputSerializer {
+
+    /**
+     * @param result completed operation result (never {@code null})
+     * @return JSON string, or {@code null} when the result cannot be serialized
+     *         (e.g. an in-test stub)
+     */
+    String serialize(OperationStatus result);
+
+    /**
+     * Default serializer: {@code Mappers.toAPI(result)} + Jackson.
+     */
+    static OperationOutputSerializer defaultSerializer() {
+        ObjectMapper mapper = new ObjectMapper();
+        return result -> {
+            try {
+                APIOperationStatus api = Mappers.toAPI(result);
+                return mapper.writeValueAsString(api);
+            } catch (JsonProcessingException e) {
+                throw new IllegalStateException("Failed to serialize OperationStatus", e);
+            }
+        };
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
@@ -10,8 +10,35 @@ public interface OperationStore {
 
     void save(OperationRecord record);
 
-    void updateStatus(String cid, OperationRecord.Status status, @Nullable OperationStatus result);
+    /**
+     * Persist a status transition with serialized outputs.
+     *
+     * <p>{@code outputsJson} should be the JSON of {@link io.ownera.ledger.adapter.api.model.APIOperationStatus}
+     * (or {@code null} when no payload is available). PR 0 added this overload because the original
+     * (cid, status, OperationStatus) signature silently dropped its result argument — the polling
+     * endpoint and idempotent-replay path both depended on persisted outputs.
+     */
+    void updateStatus(String cid, OperationRecord.Status status, @Nullable String outputsJson);
+
+    /**
+     * Backward-compatible overload that ignores the in-memory {@code OperationStatus}.
+     * New callers should serialize first and pass JSON via the {@code (cid, status, String)} overload.
+     *
+     * @deprecated kept for callers built before PR 0; will be removed in a future release.
+     */
+    @Deprecated
+    default void updateStatus(String cid, OperationRecord.Status status, @Nullable OperationStatus result) {
+        updateStatus(cid, status, (String) null);
+    }
 
     @Nullable
     OperationRecord findByCid(String cid);
+
+    /**
+     * Read the persisted outputs JSON for a cid — the serialized
+     * {@link io.ownera.ledger.adapter.api.model.APIOperationStatus}. Returns {@code null} when
+     * the cid does not exist or the operation has not yet completed (no outputs persisted).
+     */
+    @Nullable
+    String findOutputsByCid(String cid);
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
@@ -8,7 +8,24 @@ public interface OperationStore {
     @Nullable
     OperationRecord findByInputsHash(String inputsHash);
 
-    void save(OperationRecord record);
+    /**
+     * Persist a new operation row with optional pending-payload JSON.
+     *
+     * <p>Mirrors the Node skeleton's {@code createServiceProxy} contract: every known CID has a
+     * pollable payload from the moment it is created — pending while the operation is in flight,
+     * then success/failure once it finalizes. Passing {@code null} leaves the {@code outputs}
+     * column unset (useful for callers that have no payload to persist yet).
+     */
+    void save(OperationRecord record, @Nullable String pendingOutputsJson);
+
+    /**
+     * Backward-compatible overload that persists no pending payload. New callers should pass
+     * a serialized pending {@link io.ownera.ledger.adapter.api.model.APIOperationStatus} so the
+     * polling endpoint can return an in-progress payload for the cid.
+     */
+    default void save(OperationRecord record) {
+        save(record, null);
+    }
 
     /**
      * Persist a status transition with serialized outputs.

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowOutcomes.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowOutcomes.java
@@ -1,0 +1,47 @@
+package io.ownera.ledger.adapter.service.workflow;
+
+import io.ownera.ledger.adapter.service.model.ErrorDetails;
+import io.ownera.ledger.adapter.service.model.FailedAssetCreation;
+import io.ownera.ledger.adapter.service.model.FailedDepositOperation;
+import io.ownera.ledger.adapter.service.model.FailedReceiptStatus;
+import io.ownera.ledger.adapter.service.model.OperationStatus;
+import io.ownera.ledger.adapter.service.model.RejectedPlan;
+
+/**
+ * Maps method names to their failure {@link OperationStatus} variants.
+ *
+ * <p>Mirrors the Node skeleton's {@code wrappedResponse} switch
+ * (skeleton/src/workflows/service.ts): each proxied method has both a pending and a failure
+ * variant of the same status type. The executor uses this to persist a failure payload so the
+ * polling endpoint can return a proper failed-operation response instead of 404.
+ */
+public final class WorkflowOutcomes {
+
+    private WorkflowOutcomes() {}
+
+    public static OperationStatus failureFor(String method, int code, String message) {
+        ErrorDetails details = new ErrorDetails(code, message);
+        switch (method) {
+            case "createAsset":
+                return new FailedAssetCreation(details);
+            case "issue":
+            case "transfer":
+            case "redeem":
+            case "hold":
+            case "release":
+            case "rollback":
+            case "payout":
+                return new FailedReceiptStatus(details);
+            case "approvePlan":
+            case "proposeCancelPlan":
+            case "proposeResetPlan":
+            case "proposeInstructionApproval":
+                return new RejectedPlan(details);
+            case "depositInstruction":
+                return new FailedDepositOperation(details);
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown method '" + method + "' — add it to WorkflowOutcomes.failureFor()");
+        }
+    }
+}

--- a/skeleton/src/main/resources/db/migration/skeleton/V1003__operations_inputs_outputs.sql
+++ b/skeleton/src/main/resources/db/migration/skeleton/V1003__operations_inputs_outputs.sql
@@ -1,0 +1,20 @@
+-- Workflow correctness (PR 0): persist full inputs and outputs on operations.
+--
+-- Before this migration: only inputs_hash was stored, and outputs were never
+-- persisted. OperationStore.findByCid always rebuilt with result=null, so
+-- GET /api/operations/status/{cid} could never return the actual operation
+-- result and the "return cached completed result" cache-hit path in
+-- OperationExecutor.execute could never fire.
+--
+-- After: outputs hold the serialized APIOperationStatus JSON for the polling
+-- endpoint to replay directly. inputs hold the full request payload for
+-- inspection and future replay (parity with the Node skeleton's `inputs JSONB
+-- UNIQUE` shape). inputs_hash is kept as a compatibility bridge for one
+-- release; new code reads both and prefers inputs.
+
+ALTER TABLE ${schema_name}.operations
+    ADD COLUMN IF NOT EXISTS inputs  JSONB,
+    ADD COLUMN IF NOT EXISTS outputs JSONB;
+
+CREATE INDEX IF NOT EXISTS operations_status_idx
+    ON ${schema_name}.operations (status);


### PR DESCRIPTION
## Why

`DbOperationStore.updateStatus(cid, status, OperationStatus result)` silently dropped its `result` argument and `toRecord(...)` always rebuilt records with `result = null`. Consequences:

- `GET /api/operations/status/{cid}` could not return the actual operation result. The default polling path delegated to `CommonService.operationStatus` on the underlying adapter, which looks up by transaction id (wrong key for cid lookups) and throws.
- `OperationExecutor`'s "return cached completed result" cache-hit branch could never fire — `existing.result` was always null on replay.

This is the first phase of Node-skeleton parity ([PLAN](https://github.com/owneraio/finp2p-java-skeleton-adapter)). The Node design's source of truth is `operation.outputs` JSONB read directly by the workflow proxy (`skeleton/src/workflows/service.ts: createServiceProxy`); the polling endpoint returns it verbatim.

## What

### Schema
- `V1003__operations_inputs_outputs.sql` — adds `operations.inputs JSONB` + `operations.outputs JSONB` + status index. Additive, backward compatible.

### Workflow layer
- `OperationStore.updateStatus(cid, status, String outputsJson)` — new String overload that **actually persists** the serialized result.
- `OperationStore.findOutputsByCid(cid)` — reads the raw stored JSON.
- Old `(cid, status, OperationStatus result)` overload kept as a `@Deprecated` default that writes `null` outputs, for back-compat with pre-PR-0 callers.
- `DbOperationStore` implements both via jOOQ `JSONB` binding.
- `OperationOutputSerializer` — pluggable serializer (default = `Mappers.toAPI` + Jackson) so the stored bytes are exactly what the polling endpoint returns. `OperationExecutor` wraps serialization in `try/catch` — outputs are an optimization and must never block operation completion.

### Controller
- `getOperationStatus(cid)` reads from the operations table **only**. No fallback to `commonService.operationStatus` (that path looks up by transaction id, never cid). Returns `404` when the cid is unknown.

## Tests (5 new, 49/49 total)

- `storeRoundTripsOutputsJson` — JSON round-trips via JSONB (parsed-tree compare; Postgres normalizes whitespace).
- `findOutputsByCidReturnsNullForUnknownCid`
- `findOutputsByCidReturnsNullForInProgressOperation`
- `pollingEndpointReturnsPersistedOutputsVerbatim` — stages a completed `APIOperationStatusCreateAsset` with CAIP-19 `ledgerIdentifier`; asserts `GET /api/operations/status/{cid}` returns it intact.
- `pollingEndpointReturns404ForUnknownCid`

## Out of scope (PR 1)

Async service proxy + crash recovery (replay of `in_progress` operations on startup). PR 0 only fixes the persistence layer so PR 1 can build on correct foundations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)