### PR TITLE
PR 1: durable async workflow proxy + crash recovery (Node parity)

### DIFF
--- a/sample-adapter/src/main/java/io/ownera/ledger/adapter/Adapter.java
+++ b/sample-adapter/src/main/java/io/ownera/ledger/adapter/Adapter.java
@@ -18,15 +18,9 @@ public class Adapter {
 
     private final static Logger logger = LoggerFactory.getLogger(Adapter.class);
 
-    @Bean
-    public PaymentService paymentService() {
-        return new CollateralService();
-    }
-
-    @Bean
-    public PlanApprovalService planApprovalService() {
-        return new AutoPlanApprovalService();
-    }
+    // PaymentService and PlanApprovalService beans live in WorkflowProxyConfig — they are
+    // exposed as WorkflowServiceProxy-wrapped versions so all proxied payment/plan operations
+    // flow through the durable async workflow path.
 
     @Bean
     public SimpleHealthService healthService() {
@@ -43,10 +37,9 @@ public class Adapter {
         return new CryptoService();
     }
 
-    @Bean
-    public OperationExecutor operationExecutor(OperationStore operationStore) {
-        return new OperationExecutor(operationStore, null);
-    }
+    // OperationExecutor (the sync workflow path) is still available in the skeleton for adapters
+    // that prefer it over the proxy. The sample-adapter wires services through
+    // WorkflowProxyConfig instead and no longer needs this bean.
 
     // Uncomment to enable transaction lifecycle hooks:
     // @Bean

--- a/sample-adapter/src/main/java/io/ownera/ledger/adapter/config/PostgresConfiguration.java
+++ b/sample-adapter/src/main/java/io/ownera/ledger/adapter/config/PostgresConfiguration.java
@@ -1,8 +1,8 @@
 package io.ownera.ledger.adapter.config;
 
 import io.ownera.ledger.adapter.sample.db.DbLedger;
+import io.ownera.ledger.adapter.service.CommonService;
 import io.ownera.ledger.adapter.service.workflow.DbOperationStore;
-import io.ownera.ledger.adapter.service.*;
 import io.ownera.ledger.adapter.service.asset.AssetStore;
 import io.ownera.ledger.adapter.service.asset.DbAssetStore;
 import io.ownera.ledger.adapter.service.mapping.DbAccountMappingStore;
@@ -46,15 +46,9 @@ public class PostgresConfiguration {
         return new DbLedger(dslContext, ledgerSchema, assetStore, proofProvider.orElse(null));
     }
 
-    @Bean
-    public TokenService tokenService(DbLedger ledger) {
-        return ledger;
-    }
-
-    @Bean
-    public EscrowService escrowService(DbLedger ledger) {
-        return ledger;
-    }
+    // TokenService and EscrowService beans live in WorkflowProxyConfig — they are exposed as
+    // WorkflowServiceProxy-wrapped versions of DbLedger so all token/escrow operations flow
+    // through the durable async workflow path.
 
     @Bean
     public CommonService commonService(DbLedger ledger, OperationStore operationStore) {

--- a/sample-adapter/src/main/java/io/ownera/ledger/adapter/config/WorkflowProxyConfig.java
+++ b/sample-adapter/src/main/java/io/ownera/ledger/adapter/config/WorkflowProxyConfig.java
@@ -1,0 +1,163 @@
+package io.ownera.ledger.adapter.config;
+
+import io.ownera.ledger.adapter.sample.AutoPlanApprovalService;
+import io.ownera.ledger.adapter.sample.CollateralService;
+import io.ownera.ledger.adapter.sample.db.DbLedger;
+import io.ownera.ledger.adapter.service.EscrowService;
+import io.ownera.ledger.adapter.service.PaymentService;
+import io.ownera.ledger.adapter.service.PlanApprovalService;
+import io.ownera.ledger.adapter.service.TokenService;
+import io.ownera.ledger.adapter.service.workflow.CallbackClient;
+import io.ownera.ledger.adapter.service.workflow.OperationOutputSerializer;
+import io.ownera.ledger.adapter.service.workflow.OperationStore;
+import io.ownera.ledger.adapter.service.workflow.WorkflowArgsCodec;
+import io.ownera.ledger.adapter.service.workflow.WorkflowRecovery;
+import io.ownera.ledger.adapter.service.workflow.WorkflowServiceProxy;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Wires the durable async workflow path: each of TokenService / EscrowService / PaymentService /
+ * PlanApprovalService is exposed as a {@link WorkflowServiceProxy}-wrapped bean, and a single
+ * {@link ApplicationReadyEvent} listener replays any {@code IN_PROGRESS} operations left by a
+ * prior crash.
+ *
+ * <p>Mirrors the Node skeleton's {@code createServiceProxy} pattern: the proxied service methods
+ * persist a pending payload, run the real method in the background, and finalize (persist outputs
+ * + send callback). Pollers see the cid through {@code GET /api/operations/status/{cid}}.
+ *
+ * <p>Sample adapter chooses no {@link CallbackClient} (router-side polling). Real adapters can
+ * register one as a bean and the proxy will pick it up automatically.
+ */
+@Configuration
+public class WorkflowProxyConfig {
+
+    // Method-name sets per service. Non-listed methods (e.g. balance reads, proposalStatus
+    // notifications) pass through the proxy unchanged. Match the Node skeleton's wrappedResponse
+    // switch in skeleton/src/workflows/service.ts.
+    private static final Set<String> TOKEN_METHODS =
+            Set.of("createAsset", "issue", "transfer", "redeem");
+    private static final Set<String> ESCROW_METHODS =
+            Set.of("hold", "release", "rollback");
+    private static final Set<String> PAYMENT_METHODS =
+            Set.of("getDepositInstruction", "payout");
+    private static final Set<String> PLAN_METHODS =
+            Set.of("approvePlan", "proposeCancelPlan", "proposeResetPlan", "proposeInstructionApproval");
+
+    /** Background pool for the proxies; cached so idle threads exit during quiet periods. */
+    @Bean
+    public ExecutorService workflowExecutor() {
+        return Executors.newCachedThreadPool();
+    }
+
+    @Bean
+    public WorkflowArgsCodec workflowArgsCodec() {
+        return new WorkflowArgsCodec();
+    }
+
+    private WorkflowServiceProxy newHandler(Object target,
+                                            OperationStore store,
+                                            Optional<CallbackClient> callback,
+                                            ExecutorService executor,
+                                            WorkflowArgsCodec codec,
+                                            Set<String> methods) {
+        return new WorkflowServiceProxy(target, store, callback.orElse(null), executor, codec,
+                OperationOutputSerializer.defaultSerializer(), methods);
+    }
+
+    @Bean
+    @Primary
+    public TokenService tokenService(DbLedger ledger,
+                                     OperationStore store,
+                                     Optional<CallbackClient> callback,
+                                     ExecutorService workflowExecutor,
+                                     WorkflowArgsCodec codec,
+                                     List<ProxyEntry> registry) {
+        WorkflowServiceProxy handler = newHandler(ledger, store, callback, workflowExecutor, codec, TOKEN_METHODS);
+        registry.add(new ProxyEntry(handler, TOKEN_METHODS));
+        return handler.asProxy(TokenService.class);
+    }
+
+    @Bean
+    @Primary
+    public EscrowService escrowService(DbLedger ledger,
+                                       OperationStore store,
+                                       Optional<CallbackClient> callback,
+                                       ExecutorService workflowExecutor,
+                                       WorkflowArgsCodec codec,
+                                       List<ProxyEntry> registry) {
+        WorkflowServiceProxy handler = newHandler(ledger, store, callback, workflowExecutor, codec, ESCROW_METHODS);
+        registry.add(new ProxyEntry(handler, ESCROW_METHODS));
+        return handler.asProxy(EscrowService.class);
+    }
+
+    @Bean
+    @Primary
+    public PaymentService paymentService(OperationStore store,
+                                         Optional<CallbackClient> callback,
+                                         ExecutorService workflowExecutor,
+                                         WorkflowArgsCodec codec,
+                                         List<ProxyEntry> registry) {
+        CollateralService raw = new CollateralService();
+        WorkflowServiceProxy handler = newHandler(raw, store, callback, workflowExecutor, codec, PAYMENT_METHODS);
+        registry.add(new ProxyEntry(handler, PAYMENT_METHODS));
+        return handler.asProxy(PaymentService.class);
+    }
+
+    @Bean
+    @Primary
+    public PlanApprovalService planApprovalService(OperationStore store,
+                                                   Optional<CallbackClient> callback,
+                                                   ExecutorService workflowExecutor,
+                                                   WorkflowArgsCodec codec,
+                                                   List<ProxyEntry> registry) {
+        AutoPlanApprovalService raw = new AutoPlanApprovalService();
+        WorkflowServiceProxy handler = newHandler(raw, store, callback, workflowExecutor, codec, PLAN_METHODS);
+        registry.add(new ProxyEntry(handler, PLAN_METHODS));
+        return handler.asProxy(PlanApprovalService.class);
+    }
+
+    @Bean
+    public List<ProxyEntry> workflowProxyRegistry() {
+        return new ArrayList<>();
+    }
+
+    /**
+     * Run crash recovery once Spring has fully started: for each proxied service, fetch any
+     * IN_PROGRESS rows and re-drive them through the proxy. Idempotent — replayed work either
+     * completes successfully (and now matches the row's persisted outputs) or fails and writes a
+     * failure payload.
+     */
+    @Bean
+    public ApplicationListener<ApplicationReadyEvent> workflowRecoveryHook(
+            OperationStore store,
+            WorkflowArgsCodec codec,
+            List<ProxyEntry> registry) {
+        return event -> {
+            for (ProxyEntry entry : registry) {
+                WorkflowRecovery recovery = new WorkflowRecovery(
+                        store, entry.proxy, List.copyOf(entry.methods), codec);
+                recovery.replayAll();
+            }
+        };
+    }
+
+    public static final class ProxyEntry {
+        final WorkflowServiceProxy proxy;
+        final Set<String> methods;
+        ProxyEntry(WorkflowServiceProxy proxy, Set<String> methods) {
+            this.proxy = proxy;
+            this.methods = methods;
+        }
+    }
+}

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/TestHelpers.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/TestHelpers.java
@@ -37,7 +37,7 @@ public class TestHelpers {
         ResponseEntity<APICreateAssetResponse> resp =
                 rest.postForEntity("/api/assets/create", entity, APICreateAssetResponse.class);
         assertEquals(200, resp.getStatusCodeValue(), "createAsset failed: " + resp.getBody());
-        return resp.getBody();
+        return awaitCreateAssetCompletion(resp.getBody());
     }
 
     public APIReceiptOperation issue(APIIssueAssetsRequest request) {
@@ -45,7 +45,7 @@ public class TestHelpers {
         ResponseEntity<APIReceiptOperation> resp =
                 rest.postForEntity("/api/assets/issue", entity, APIReceiptOperation.class);
         assertEquals(200, resp.getStatusCodeValue(), "issue failed");
-        return resp.getBody();
+        return awaitReceiptCompletion(resp.getBody());
     }
 
     public APIReceiptOperation transfer(APITransferAssetRequest request) {
@@ -53,7 +53,7 @@ public class TestHelpers {
         ResponseEntity<APIReceiptOperation> resp =
                 rest.postForEntity("/api/assets/transfer", entity, APIReceiptOperation.class);
         assertEquals(200, resp.getStatusCodeValue(), "transfer failed");
-        return resp.getBody();
+        return awaitReceiptCompletion(resp.getBody());
     }
 
     public APIReceiptOperation redeem(APIRedeemAssetsRequest request) {
@@ -61,7 +61,7 @@ public class TestHelpers {
         ResponseEntity<APIReceiptOperation> resp =
                 rest.postForEntity("/api/assets/redeem", entity, APIReceiptOperation.class);
         assertEquals(200, resp.getStatusCodeValue(), "redeem failed");
-        return resp.getBody();
+        return awaitReceiptCompletion(resp.getBody());
     }
 
     public APIReceiptOperation hold(APIHoldOperationRequest request) {
@@ -69,7 +69,7 @@ public class TestHelpers {
         ResponseEntity<APIReceiptOperation> resp =
                 rest.postForEntity("/api/assets/hold", entity, APIReceiptOperation.class);
         assertEquals(200, resp.getStatusCodeValue(), "hold failed");
-        return resp.getBody();
+        return awaitReceiptCompletion(resp.getBody());
     }
 
     public APIReceiptOperation release(APIReleaseOperationRequest request) {
@@ -77,7 +77,7 @@ public class TestHelpers {
         ResponseEntity<APIReceiptOperation> resp =
                 rest.postForEntity("/api/assets/release", entity, APIReceiptOperation.class);
         assertEquals(200, resp.getStatusCodeValue(), "release failed");
-        return resp.getBody();
+        return awaitReceiptCompletion(resp.getBody());
     }
 
     public APIReceiptOperation rollback(APIRollbackOperationRequest request) {
@@ -85,7 +85,64 @@ public class TestHelpers {
         ResponseEntity<APIReceiptOperation> resp =
                 rest.postForEntity("/api/assets/rollback", entity, APIReceiptOperation.class);
         assertEquals(200, resp.getStatusCodeValue(), "rollback failed");
-        return resp.getBody();
+        return awaitReceiptCompletion(resp.getBody());
+    }
+
+    // --- Pending-to-completed polling ---
+    //
+    // The sample-adapter now routes proxied service methods through WorkflowServiceProxy, which
+    // returns a Pending payload immediately and finalizes in the background. To preserve the
+    // sync-style assertions in the test suite (assertSuccessReceipt etc.), each helper waits for
+    // the operation's cid to reach a completed state via the polling endpoint, then returns the
+    // finalized payload mapped back to the endpoint's response shape.
+
+    private static final int POLL_MAX_ATTEMPTS = 100;
+    private static final long POLL_INTERVAL_MS = 50L;
+
+    private APIReceiptOperation awaitReceiptCompletion(APIReceiptOperation pending) {
+        if (pending == null || Boolean.TRUE.equals(pending.getIsCompleted())) return pending;
+        APIOperationStatusReceipt wrapped = pollFor(pending.getCid(), APIOperationStatusReceipt.class);
+        return wrapped != null ? wrapped.getOperation() : pending;
+    }
+
+    private APICreateAssetResponse awaitCreateAssetCompletion(APICreateAssetResponse pending) {
+        if (pending == null || Boolean.TRUE.equals(pending.getIsCompleted())) return pending;
+        APIOperationStatusCreateAsset wrapped = pollFor(pending.getCid(), APIOperationStatusCreateAsset.class);
+        if (wrapped == null) return pending;
+        APICreateAssetOperation op = wrapped.getOperation();
+        return new APICreateAssetResponse()
+                .cid(op.getCid())
+                .isCompleted(op.getIsCompleted())
+                .operationMetadata(op.getOperationMetadata())
+                .error(op.getError())
+                .response(op.getResponse());
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> T pollFor(String cid, Class<T> wrappedType) {
+        if (cid == null || cid.isEmpty()) return null;
+        for (int i = 0; i < POLL_MAX_ATTEMPTS; i++) {
+            ResponseEntity<APIOperationStatus> resp = rest.getForEntity(
+                    "/api/operations/status/" + cid, APIOperationStatus.class);
+            if (resp.getStatusCodeValue() == 200 && resp.getBody() != null) {
+                Object actual = resp.getBody().getActualInstance();
+                if (wrappedType.isInstance(actual)) {
+                    Boolean done = isCompleted(actual);
+                    if (Boolean.TRUE.equals(done)) return (T) actual;
+                }
+            }
+            try { Thread.sleep(POLL_INTERVAL_MS); } catch (InterruptedException ignored) { return null; }
+        }
+        throw new AssertionError("Operation cid=" + cid + " did not complete within "
+                + (POLL_MAX_ATTEMPTS * POLL_INTERVAL_MS) + " ms");
+    }
+
+    private Boolean isCompleted(Object wrapped) {
+        if (wrapped instanceof APIOperationStatusReceipt) return ((APIOperationStatusReceipt) wrapped).getOperation().getIsCompleted();
+        if (wrapped instanceof APIOperationStatusCreateAsset) return ((APIOperationStatusCreateAsset) wrapped).getOperation().getIsCompleted();
+        if (wrapped instanceof APIOperationStatusDeposit) return ((APIOperationStatusDeposit) wrapped).getOperation().getIsCompleted();
+        if (wrapped instanceof APIOperationStatusApproval) return ((APIOperationStatusApproval) wrapped).getOperation().getIsCompleted();
+        return Boolean.FALSE;
     }
 
     public APIGetAssetBalanceResponse getBalance(APIAsset asset, String finId) {

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
@@ -268,6 +268,37 @@ public class WorkflowServiceProxyTest {
     }
 
     @Test
+    void duplicateCallAfterFailureReturnsFailurePayload() throws Exception {
+        // Reviewer-flagged regression: a duplicate POST after the first call FAILED used to fall
+        // through to a fresh Pending placeholder. Node returns operation.outputs verbatim for
+        // any existing row, so the duplicate must immediately surface the original failure.
+        StubTokenService stub = new StubTokenService();
+        stub.failWith = new RuntimeException("boom");
+        TokenService proxied = wrap(stub, null);
+
+        String ik = "ik-fail-dup-" + System.nanoTime();
+        Asset a = asset("ast-FAIL-DUP");
+
+        AssetCreationStatus first = proxied.createAsset(ik, a, null, null, null, null, null);
+        String cid = ((PendingAssetCreation) first).correlationId;
+
+        // Wait for the row to reach FAILED.
+        for (int i = 0; i < 100; i++) {
+            OperationRecord r = store.findByCid(cid);
+            if (r != null && r.status == OperationRecord.Status.FAILED) break;
+            Thread.sleep(50);
+        }
+
+        // Stop the underlying service from throwing — a subsequent call must NOT re-run it.
+        stub.failWith = null;
+        AssetCreationStatus second = proxied.createAsset(ik, a, null, null, null, null, null);
+
+        assertTrue(second instanceof io.ownera.ledger.adapter.service.model.FailedAssetCreation,
+                "duplicate after failure must return the persisted failure, got " + second.getClass());
+        assertEquals(1, stub.createCalls, "underlying service must run exactly once across failure + duplicate");
+    }
+
+    @Test
     void duplicateCallShortCircuitsToExistingOutputs() throws Exception {
         StubTokenService stub = new StubTokenService();
         TokenService proxied = wrap(stub, null);

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
@@ -202,6 +202,72 @@ public class WorkflowServiceProxyTest {
     }
 
     @Test
+    void tryInsertOnInputsHashConflictReturnsFalseInsteadOfThrowing() {
+        // Direct store-level race proof: two tryInsert calls with the same inputs_hash and
+        // different cids must NOT both succeed and must NOT throw on the second. The second
+        // call gets false and the row keeps the first cid.
+        String inputsHash = "hash-race-" + System.nanoTime();
+        OperationRecord first = new OperationRecord(
+                "cid-first-" + System.nanoTime(), "createAsset",
+                OperationRecord.Status.IN_PROGRESS, inputsHash, null);
+        OperationRecord second = new OperationRecord(
+                "cid-second-" + System.nanoTime(), "createAsset",
+                OperationRecord.Status.IN_PROGRESS, inputsHash, null);
+
+        assertTrue(store.tryInsert(first, (String) null, "{\"a\":1}"), "first insert must win");
+        assertFalse(store.tryInsert(second, (String) null, "{\"a\":2}"),
+                "second insert with the same inputs_hash must report conflict (false), not throw");
+
+        OperationRecord winner = store.findByInputsHash(inputsHash);
+        assertNotNull(winner);
+        assertEquals(first.cid, winner.cid, "winning row must keep the first cid");
+    }
+
+    @Test
+    void concurrentDuplicateCallsBothShortCircuit() throws Exception {
+        // Race test: two concurrent identical calls used to blow up the loser on the unique
+        // inputs_hash constraint because the lookup + insert path was non-atomic. With
+        // tryInsert (ON CONFLICT DO NOTHING) the loser must instead see the winner's row and
+        // return a Pending placeholder for the same cid.
+        StubTokenService stub = new StubTokenService();
+        stub.hold = true; // both calls' background work blocks so neither finalizes early
+        TokenService proxied = wrap(stub, null);
+        try {
+            String ik = "ik-race-" + System.nanoTime();
+            Asset a = asset("ast-RACE");
+            java.util.concurrent.CountDownLatch start = new java.util.concurrent.CountDownLatch(1);
+            java.util.concurrent.CompletableFuture<AssetCreationStatus> f1 = new java.util.concurrent.CompletableFuture<>();
+            java.util.concurrent.CompletableFuture<AssetCreationStatus> f2 = new java.util.concurrent.CompletableFuture<>();
+            Runnable call = () -> {
+                try {
+                    start.await();
+                    f1.complete(proxied.createAsset(ik, a, null, null, null, null, null));
+                } catch (Throwable t) { f1.completeExceptionally(t); }
+            };
+            Runnable call2 = () -> {
+                try {
+                    start.await();
+                    f2.complete(proxied.createAsset(ik, a, null, null, null, null, null));
+                } catch (Throwable t) { f2.completeExceptionally(t); }
+            };
+            new Thread(call).start();
+            new Thread(call2).start();
+            start.countDown();
+            AssetCreationStatus r1 = f1.get(5, java.util.concurrent.TimeUnit.SECONDS);
+            AssetCreationStatus r2 = f2.get(5, java.util.concurrent.TimeUnit.SECONDS);
+            assertTrue(r1 instanceof PendingAssetCreation, "first call must return Pending, got " + r1.getClass());
+            assertTrue(r2 instanceof PendingAssetCreation, "second call must return Pending (not blow up), got " + r2.getClass());
+            // Both must point at the same cid — Node's saveOperation guarantees a single winner.
+            assertEquals(((PendingAssetCreation) r1).correlationId,
+                    ((PendingAssetCreation) r2).correlationId,
+                    "both concurrent calls must converge on the same cid");
+            assertEquals(1, stub.createCalls, "underlying service must run exactly once across the race");
+        } finally {
+            stub.released.countDown();
+        }
+    }
+
+    @Test
     void duplicateCallShortCircuitsToExistingOutputs() throws Exception {
         StubTokenService stub = new StubTokenService();
         TokenService proxied = wrap(stub, null);

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
@@ -1,0 +1,285 @@
+package io.ownera.ledger.adapter.postgres;
+
+import io.ownera.ledger.adapter.PostgresContainerHolder;
+import io.ownera.ledger.adapter.service.TokenService;
+import io.ownera.ledger.adapter.service.TokenServiceException;
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.AssetBind;
+import io.ownera.ledger.adapter.service.model.AssetCreationResult;
+import io.ownera.ledger.adapter.service.model.AssetCreationStatus;
+import io.ownera.ledger.adapter.service.model.AssetDenomination;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import io.ownera.ledger.adapter.service.model.Balance;
+import io.ownera.ledger.adapter.service.model.ExecutionContext;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+import io.ownera.ledger.adapter.service.model.LedgerReference;
+import io.ownera.ledger.adapter.service.model.OperationStatus;
+import io.ownera.ledger.adapter.service.model.PendingAssetCreation;
+import io.ownera.ledger.adapter.service.model.ReceiptOperation;
+import io.ownera.ledger.adapter.service.model.Signature;
+import io.ownera.ledger.adapter.service.model.Source;
+import io.ownera.ledger.adapter.service.model.Destination;
+import io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation;
+import io.ownera.ledger.adapter.service.workflow.CallbackClient;
+import io.ownera.ledger.adapter.service.workflow.DbOperationStore;
+import io.ownera.ledger.adapter.service.workflow.OperationOutputSerializer;
+import io.ownera.ledger.adapter.service.workflow.OperationRecord;
+import io.ownera.ledger.adapter.service.workflow.OperationStore;
+import io.ownera.ledger.adapter.service.workflow.WorkflowArgsCodec;
+import io.ownera.ledger.adapter.service.workflow.WorkflowRecovery;
+import io.ownera.ledger.adapter.service.workflow.WorkflowServiceProxy;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+
+import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for the PR 1 durable-workflow path: {@link WorkflowServiceProxy} captures method args,
+ * persists pending + inputs, runs the real method in the background, finalizes (persists outputs
+ * + sends callback), and {@link WorkflowRecovery} replays IN_PROGRESS rows on startup.
+ */
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class WorkflowServiceProxyTest {
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("DB_CONNECTION_STRING", PostgresContainerHolder.POSTGRES::getJdbcUrl);
+        registry.add("DB_USERNAME", PostgresContainerHolder.POSTGRES::getUsername);
+        registry.add("DB_PASSWORD", PostgresContainerHolder.POSTGRES::getPassword);
+    }
+
+    @Autowired
+    private DSLContext dsl;
+
+    private OperationStore store;
+    private WorkflowArgsCodec argsCodec;
+
+    @BeforeEach
+    void setup() {
+        store = new DbOperationStore(dsl, "sample_adapter");
+        argsCodec = new WorkflowArgsCodec();
+    }
+
+    /**
+     * Minimal in-memory {@link TokenService} stub. Only {@code createAsset} is exercised here;
+     * the other methods throw to fail-fast if called unexpectedly.
+     */
+    static class StubTokenService implements TokenService {
+        final CountDownLatch released = new CountDownLatch(1);
+        volatile boolean hold = false;
+        volatile @Nullable RuntimeException failWith = null;
+        volatile int createCalls = 0;
+
+        @Override
+        public AssetCreationStatus createAsset(String idempotencyKey, Asset asset,
+                                               @Nullable AssetBind assetBind, @Nullable Object assetMetadata,
+                                               @Nullable String assetName, @Nullable String issuerId,
+                                               @Nullable AssetDenomination assetDenomination) {
+            createCalls++;
+            if (hold) {
+                try { released.await(); } catch (InterruptedException ignored) {}
+            }
+            if (failWith != null) throw failWith;
+            return new SuccessfulAssetCreation(new AssetCreationResult(
+                    "tok-" + asset.assetId,
+                    new LedgerReference("hedera:testnet", "0x0", "HTS", null)));
+        }
+
+        @Override
+        public ReceiptOperation issue(String idempotencyKey, Asset asset, FinIdAccount to, String amount,
+                                      @Nullable ExecutionContext exCtx) { throw new UnsupportedOperationException(); }
+        @Override
+        public ReceiptOperation transfer(String idempotencyKey, String nonce, Source source, Destination destination,
+                                         Asset asset, String quantity, Signature signature,
+                                         @Nullable ExecutionContext exCtx) { throw new UnsupportedOperationException(); }
+        @Override
+        public ReceiptOperation redeem(String idempotencyKey, String nonce, FinIdAccount source, Asset asset,
+                                       String quantity, @Nullable String operationId, Signature signature,
+                                       @Nullable ExecutionContext exCtx) { throw new UnsupportedOperationException(); }
+        @Override public String getBalance(Asset asset, String finId) { return "0"; }
+        @Override public Balance balance(Asset asset, String finId) { throw new UnsupportedOperationException(); }
+    }
+
+    static class RecordingCallback implements CallbackClient {
+        volatile @Nullable String lastCid;
+        volatile @Nullable OperationStatus lastResult;
+        final CountDownLatch fired = new CountDownLatch(1);
+
+        @Override
+        public void sendCallback(String cid, OperationStatus result) {
+            lastCid = cid;
+            lastResult = result;
+            fired.countDown();
+        }
+    }
+
+    private TokenService wrap(StubTokenService target, @Nullable CallbackClient callback) {
+        return WorkflowServiceProxy.wrap(TokenService.class, target, store, callback,
+                Executors.newCachedThreadPool(), argsCodec,
+                OperationOutputSerializer.defaultSerializer(),
+                Set.of("createAsset", "issue", "transfer", "redeem"));
+    }
+
+    private Asset asset(String id) {
+        return new Asset(id, AssetType.FINP2P);
+    }
+
+    @Test
+    void proxyReturnsPendingImmediatelyAndPersistsRow() throws Exception {
+        StubTokenService stub = new StubTokenService();
+        stub.hold = true; // keep work in-flight while we inspect storage
+        TokenService proxied = wrap(stub, null);
+        try {
+            String ik = "ik-pending-" + System.nanoTime();
+            AssetCreationStatus result = proxied.createAsset(ik, asset("ast-1"), null, null, null, null, null);
+
+            assertTrue(result instanceof PendingAssetCreation,
+                    "proxy must return Pending immediately, got " + result.getClass());
+            String cid = ((PendingAssetCreation) result).correlationId;
+            assertNotNull(cid);
+
+            String stored = store.findOutputsByCid(cid);
+            assertNotNull(stored, "pending payload must be persisted at save time");
+            // Postgres JSONB normalizes whitespace; parse before comparing.
+            com.fasterxml.jackson.databind.JsonNode parsed = new com.fasterxml.jackson.databind.ObjectMapper().readTree(stored);
+            assertEquals(false, parsed.at("/operation/isCompleted").asBoolean(true), stored);
+        } finally {
+            stub.released.countDown();
+        }
+    }
+
+    @Test
+    void proxyFinalizesSuccessAndCallsCallback() throws Exception {
+        StubTokenService stub = new StubTokenService();
+        RecordingCallback cb = new RecordingCallback();
+        TokenService proxied = wrap(stub, cb);
+
+        String ik = "ik-success-" + System.nanoTime();
+        AssetCreationStatus result = proxied.createAsset(ik, asset("ast-S"), null, null, null, null, null);
+        String cid = ((PendingAssetCreation) result).correlationId;
+
+        assertTrue(cb.fired.await(5, TimeUnit.SECONDS), "callback must fire after persistence");
+        assertEquals(cid, cb.lastCid);
+        assertTrue(cb.lastResult instanceof SuccessfulAssetCreation, "callback must carry the success payload");
+
+        OperationRecord rec = store.findByCid(cid);
+        assertNotNull(rec);
+        assertEquals(OperationRecord.Status.COMPLETED, rec.status);
+        assertTrue(rec.result instanceof SuccessfulAssetCreation,
+                "result must be reconstructable from persisted outputs");
+    }
+
+    @Test
+    void proxyFinalizesFailureAndCallsCallback() throws Exception {
+        StubTokenService stub = new StubTokenService();
+        stub.failWith = new RuntimeException("simulated failure");
+        RecordingCallback cb = new RecordingCallback();
+        TokenService proxied = wrap(stub, cb);
+
+        String ik = "ik-failure-" + System.nanoTime();
+        AssetCreationStatus result = proxied.createAsset(ik, asset("ast-F"), null, null, null, null, null);
+        String cid = ((PendingAssetCreation) result).correlationId;
+
+        assertTrue(cb.fired.await(5, TimeUnit.SECONDS), "callback must also fire on failure");
+        assertEquals(cid, cb.lastCid);
+        assertNotNull(cb.lastResult, "callback must carry the failure payload");
+
+        OperationRecord rec = store.findByCid(cid);
+        assertNotNull(rec);
+        assertEquals(OperationRecord.Status.FAILED, rec.status);
+    }
+
+    @Test
+    void duplicateCallShortCircuitsToExistingOutputs() throws Exception {
+        StubTokenService stub = new StubTokenService();
+        TokenService proxied = wrap(stub, null);
+
+        String ik = "ik-dedup-" + System.nanoTime();
+        Asset a = asset("ast-DUP");
+
+        AssetCreationStatus first = proxied.createAsset(ik, a, null, null, null, null, null);
+        String cid = ((PendingAssetCreation) first).correlationId;
+
+        // Wait for the first call to finalize.
+        for (int i = 0; i < 50; i++) {
+            OperationRecord r = store.findByCid(cid);
+            if (r != null && r.status == OperationRecord.Status.COMPLETED) break;
+            Thread.sleep(50);
+        }
+
+        AssetCreationStatus second = proxied.createAsset(ik, a, null, null, null, null, null);
+        assertTrue(second instanceof SuccessfulAssetCreation,
+                "second identical call must return the cached success payload, got " + second.getClass());
+        assertEquals(1, stub.createCalls, "underlying service must run once across duplicate requests");
+    }
+
+    @Test
+    void nonProxiedMethodPassesThrough() {
+        StubTokenService stub = new StubTokenService();
+        TokenService proxied = wrap(stub, null);
+        // getBalance is not in the proxied set — should call the target directly without
+        // persisting a row.
+        String balance = proxied.getBalance(asset("ast-B"), "fin-1");
+        assertEquals("0", balance);
+    }
+
+    @Test
+    void recoveryReplaysPendingRowsAfterRestart() throws Exception {
+        // Simulate a crash: build a proxy whose underlying service blocks forever, kick off a
+        // call (row is now IN_PROGRESS with persisted inputs), then build a fresh proxy whose
+        // service finalizes immediately, and run recovery — the original cid should now reach
+        // COMPLETED via the new proxy.
+        StubTokenService crashed = new StubTokenService();
+        crashed.hold = true;
+        TokenService crashedProxy = wrap(crashed, null);
+
+        String ik = "ik-recovery-" + System.nanoTime();
+        AssetCreationStatus pending = crashedProxy.createAsset(ik, asset("ast-R"), null, null, null, null, null);
+        String cid = ((PendingAssetCreation) pending).correlationId;
+
+        // Sanity: row is IN_PROGRESS.
+        OperationRecord midflight = store.findByCid(cid);
+        assertNotNull(midflight);
+        assertEquals(OperationRecord.Status.IN_PROGRESS, midflight.status);
+
+        // Restart: build a new service + new proxy handler as if after a JVM boot.
+        StubTokenService restarted = new StubTokenService(); // finalizes immediately
+        WorkflowServiceProxy handler = new WorkflowServiceProxy(
+                restarted, store, null, Executors.newCachedThreadPool(),
+                argsCodec, OperationOutputSerializer.defaultSerializer(),
+                Set.of("createAsset", "issue", "transfer", "redeem"));
+        WorkflowRecovery recovery = new WorkflowRecovery(store, handler,
+                List.of("createAsset", "issue", "transfer", "redeem"), argsCodec);
+        recovery.replayAll();
+
+        // Wait for the replayed operation to finalize.
+        OperationRecord finalRec = null;
+        for (int i = 0; i < 100; i++) {
+            finalRec = store.findByCid(cid);
+            if (finalRec != null && finalRec.status == OperationRecord.Status.COMPLETED) break;
+            Thread.sleep(50);
+        }
+        assertNotNull(finalRec);
+        assertEquals(OperationRecord.Status.COMPLETED, finalRec.status,
+                "recovery must finalize the IN_PROGRESS row");
+        assertTrue(finalRec.result instanceof SuccessfulAssetCreation);
+        assertEquals(1, restarted.createCalls,
+                "recovery must call the (restarted) underlying service exactly once");
+
+        // Quiet the original "crashed" worker so the test pool can shut down.
+        crashed.released.countDown();
+    }
+
+}

--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
@@ -1,6 +1,8 @@
 package io.ownera.ledger.adapter.postgres;
 
 import io.ownera.ledger.adapter.PostgresContainerHolder;
+import io.ownera.ledger.adapter.api.model.APILedgerAssetIdentifierTypeCAIP19;
+import io.ownera.ledger.adapter.api.model.APIOperationStatusCreateAsset;
 import io.ownera.ledger.adapter.service.TokenService;
 import io.ownera.ledger.adapter.service.TokenServiceException;
 import io.ownera.ledger.adapter.service.model.Asset;
@@ -255,12 +257,14 @@ public class WorkflowServiceProxyTest {
             start.countDown();
             AssetCreationStatus r1 = f1.get(5, java.util.concurrent.TimeUnit.SECONDS);
             AssetCreationStatus r2 = f2.get(5, java.util.concurrent.TimeUnit.SECONDS);
-            assertTrue(r1 instanceof PendingAssetCreation, "first call must return Pending, got " + r1.getClass());
-            assertTrue(r2 instanceof PendingAssetCreation, "second call must return Pending (not blow up), got " + r2.getClass());
-            // Both must point at the same cid — Node's saveOperation guarantees a single winner.
-            assertEquals(((PendingAssetCreation) r1).correlationId,
-                    ((PendingAssetCreation) r2).correlationId,
-                    "both concurrent calls must converge on the same cid");
+            // Winner returns its own freshly-built Pending; loser hits resolveExisting and
+            // returns a CachedJsonOperationStatus wrapping the persisted pending payload. Both
+            // must carry the same cid.
+            String c1 = extractCid(r1);
+            String c2 = extractCid(r2);
+            assertNotNull(c1, "first call must carry a cid, got " + r1.getClass());
+            assertNotNull(c2, "second call must carry a cid, got " + r2.getClass());
+            assertEquals(c1, c2, "both concurrent calls must converge on the same cid");
             assertEquals(1, stub.createCalls, "underlying service must run exactly once across the race");
         } finally {
             stub.released.countDown();
@@ -293,13 +297,22 @@ public class WorkflowServiceProxyTest {
         stub.failWith = null;
         AssetCreationStatus second = proxied.createAsset(ik, a, null, null, null, null, null);
 
-        assertTrue(second instanceof io.ownera.ledger.adapter.service.model.FailedAssetCreation,
-                "duplicate after failure must return the persisted failure, got " + second.getClass());
+        assertTrue(second instanceof io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus,
+                "duplicate after failure must return the cached marker wrapping stored JSON, got " + second.getClass());
+        APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset)
+                ((io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus) second).apiStatus.getActualInstance();
+        assertTrue(wrap.getOperation().getIsCompleted());
+        assertNotNull(wrap.getOperation().getError(), "cached duplicate must carry the original failure payload");
         assertEquals(1, stub.createCalls, "underlying service must run exactly once across failure + duplicate");
     }
 
     @Test
     void duplicateCallShortCircuitsToExistingOutputs() throws Exception {
+        // Duplicate POST on a COMPLETED row returns the stored outputs JSON byte-faithfully via
+        // the CachedJsonOperationStatus marker. This is the Node createServiceProxy contract:
+        // "if (!inserted) return storageOperation.outputs" — the wire response on a duplicate must
+        // match the original, including fields that the internal-model round-trip would drop
+        // (LedgerReference.network/standard, here).
         StubTokenService stub = new StubTokenService();
         TokenService proxied = wrap(stub, null);
 
@@ -317,9 +330,23 @@ public class WorkflowServiceProxyTest {
         }
 
         AssetCreationStatus second = proxied.createAsset(ik, a, null, null, null, null, null);
-        assertTrue(second instanceof SuccessfulAssetCreation,
-                "second identical call must return the cached success payload, got " + second.getClass());
+        assertTrue(second instanceof io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus,
+                "duplicate must return the cached marker wrapping stored JSON, got " + second.getClass());
         assertEquals(1, stub.createCalls, "underlying service must run once across duplicate requests");
+
+        // Byte-faithfulness: network + standard survive on the duplicate. The internal-model
+        // round-trip (Mappers.fromAPI(create)) drops LedgerReference, so without the cached
+        // marker these fields would come back as empty strings.
+        APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset)
+                ((io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus) second).apiStatus.getActualInstance();
+        APILedgerAssetIdentifierTypeCAIP19 caip19 = (APILedgerAssetIdentifierTypeCAIP19)
+                wrap.getOperation().getResponse().getLedgerAssetInfo()
+                        .getLedgerIdentifier().getActualInstance();
+        assertEquals("hedera:testnet", caip19.getNetwork(),
+                "network must round-trip on cached duplicate");
+        assertEquals("HTS", caip19.getStandard(),
+                "standard must round-trip on cached duplicate");
+        assertEquals("tok-ast-DUP", caip19.getTokenId());
     }
 
     @Test
@@ -330,6 +357,20 @@ public class WorkflowServiceProxyTest {
         // persisting a row.
         String balance = proxied.getBalance(asset("ast-B"), "fin-1");
         assertEquals("0", balance);
+    }
+
+    /** Pulls the cid out of either a freshly-built Pending (winner of an insert race) or a
+     * CachedJsonOperationStatus marker (loser, or any duplicate hit). */
+    private static String extractCid(AssetCreationStatus s) {
+        if (s instanceof PendingAssetCreation) {
+            return ((PendingAssetCreation) s).correlationId;
+        }
+        if (s instanceof io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus) {
+            APIOperationStatusCreateAsset wrap = (APIOperationStatusCreateAsset)
+                    ((io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus) s).apiStatus.getActualInstance();
+            return wrap.getOperation().getCid();
+        }
+        return null;
     }
 
     @Test

--- a/skeleton/pom.xml
+++ b/skeleton/pom.xml
@@ -54,6 +54,14 @@
             <version>2.20.0</version>
         </dependency>
         <dependency>
+            <!-- Lets Jackson bind JSON properties to constructor parameters of immutable POJOs
+                 (no default constructor needed). Pairs with -parameters compile flag above.
+                 Version pinned to match the other Jackson modules above. -->
+            <groupId>com.fasterxml.jackson.module</groupId>
+            <artifactId>jackson-module-parameter-names</artifactId>
+            <version>2.20.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.netbeans.external</groupId>
             <artifactId>org-apache-commons-logging</artifactId>
             <version>RELEASE210</version>
@@ -108,6 +116,10 @@
                 <configuration>
                     <source>11</source>
                     <target>11</target>
+                    <!-- Preserve constructor parameter names so Jackson can bind JSON
+                         properties to immutable POJOs without @JsonCreator annotations.
+                         Required by WorkflowArgsCodec for crash-recovery replay. -->
+                    <parameters>true</parameters>
                 </configuration>
             </plugin>
         </plugins>

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Controller.java
@@ -5,7 +5,6 @@ import io.ownera.ledger.adapter.api.model.*;
 import io.ownera.ledger.adapter.service.*;
 import io.ownera.ledger.adapter.service.model.*;
 import io.ownera.ledger.adapter.service.workflow.CorrelationIdGenerator;
-import io.ownera.ledger.adapter.service.workflow.OperationExecutor;
 import io.ownera.ledger.adapter.service.workflow.OperationStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,7 +16,6 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 import static io.ownera.ledger.adapter.Mappers.*;
-import static io.ownera.ledger.adapter.service.workflow.OperationExecutor.computeInputsHash;
 
 @RestController
 public class Controller {
@@ -29,7 +27,6 @@ public class Controller {
     private final CommonService commonService;
     private final HealthService healthService;
     private final SignatureVerifier signatureVerifier;
-    private final OperationExecutor operationExecutor;
     private final Optional<TransactionHook> transactionHook;
     private final OperationStore operationStore;
     private final ObjectMapper objectMapper = new ObjectMapper();
@@ -37,7 +34,7 @@ public class Controller {
     public Controller(EscrowService escrowService, TokenService tokenService, PaymentService paymentService,
                       PlanApprovalService planApprovalService, CommonService commonService,
                       HealthService healthService, SignatureVerifier signatureVerifier,
-                      OperationExecutor operationExecutor, Optional<TransactionHook> transactionHook,
+                      Optional<TransactionHook> transactionHook,
                       OperationStore operationStore) {
         this.escrowService = escrowService;
         this.tokenService = tokenService;
@@ -46,7 +43,6 @@ public class Controller {
         this.commonService = commonService;
         this.healthService = healthService;
         this.signatureVerifier = signatureVerifier;
-        this.operationExecutor = operationExecutor;
         this.transactionHook = transactionHook;
         this.operationStore = operationStore;
     }
@@ -94,11 +90,7 @@ public class Controller {
         String ik = ensureIdempotencyKey(idempotencyKey);
         String planId = request.getExecutionPlan().getId();
         logger.info("Approve plan: {}", planId);
-        PlanApprovalStatus status = operationExecutor.execute(
-                "approvePlan", computeInputsHash("approvePlan", ik, planId),
-                () -> planApprovalService.approvePlan(ik, planId),
-                cid -> new PendingPlan(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        PlanApprovalStatus status = planApprovalService.approvePlan(ik, planId);
         return ResponseEntity.status(HttpStatus.OK).body(toAPIResponse(status));
     }
 
@@ -114,27 +106,15 @@ public class Controller {
 
         PlanApprovalStatus status;
         if (proposal instanceof APIExecutionPlanCancellationProposal) {
-            status = operationExecutor.execute(
-                    "proposeCancelPlan", computeInputsHash("proposeCancelPlan", ik, planId),
-                    () -> planApprovalService.proposeCancelPlan(ik, planId),
-                    cid -> new PendingPlan(cid, new OperationMetadata(new PollingResponseStrategy()))
-            );
+            status = planApprovalService.proposeCancelPlan(ik, planId);
         } else if (proposal instanceof APIExecutionPlanResetProposal) {
             APIExecutionPlanResetProposal reset = (APIExecutionPlanResetProposal) proposal;
             int seq = reset.getProposedSequence() != null ? reset.getProposedSequence() : 0;
-            status = operationExecutor.execute(
-                    "proposeResetPlan", computeInputsHash("proposeResetPlan", ik, planId, String.valueOf(seq)),
-                    () -> planApprovalService.proposeResetPlan(ik, planId, seq),
-                    cid -> new PendingPlan(cid, new OperationMetadata(new PollingResponseStrategy()))
-            );
+            status = planApprovalService.proposeResetPlan(ik, planId, seq);
         } else if (proposal instanceof APIExecutionPlanInstructionProposal) {
             APIExecutionPlanInstructionProposal instr = (APIExecutionPlanInstructionProposal) proposal;
             int seq = instr.getInstructionSequence() != null ? instr.getInstructionSequence() : 0;
-            status = operationExecutor.execute(
-                    "proposeInstructionApproval", computeInputsHash("proposeInstructionApproval", ik, planId, String.valueOf(seq)),
-                    () -> planApprovalService.proposeInstructionApproval(ik, planId, seq),
-                    cid -> new PendingPlan(cid, new OperationMetadata(new PollingResponseStrategy()))
-            );
+            status = planApprovalService.proposeInstructionApproval(ik, planId, seq);
         } else {
             logger.warn("Unknown proposal type: {}", proposal.getClass().getName());
             status = new ApprovedPlan();
@@ -166,18 +146,14 @@ public class Controller {
     ) {
         String ik = ensureIdempotencyKey(idempotencyKey);
         logger.info("Create asset: {}", request);
-        AssetCreationStatus status = operationExecutor.execute(
-                "createAsset", computeInputsHash("createAsset", ik, request.toString()),
-                () -> tokenService.createAsset(
-                        ik,
-                        fromAPI(request.getAsset()),
-                        fromAPI(request.getLedgerAssetBinding()),
-                        request.getMetadata(),
-                        request.getName(),
-                        request.getIssuerId(),
-                        fromAPI(request.getDenomination())
-                ),
-                cid -> new PendingAssetCreation(cid, new OperationMetadata(new PollingResponseStrategy()))
+        AssetCreationStatus status = tokenService.createAsset(
+                ik,
+                fromAPI(request.getAsset()),
+                fromAPI(request.getLedgerAssetBinding()),
+                request.getMetadata(),
+                request.getName(),
+                request.getIssuerId(),
+                fromAPI(request.getDenomination())
         );
         return ResponseEntity.status(HttpStatus.OK).body(toAPIResponse(status));
     }
@@ -199,11 +175,7 @@ public class Controller {
         transactionHook.ifPresent(h -> h.preTransaction(
                 ik, OperationType.ISSUE, null,
                 destination.destination(), asset, request.getQuantity(), null, exCtx));
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "issue", computeInputsHash("issue", ik, request.toString()),
-                () -> tokenService.issue(ik, asset, destination, request.getQuantity(), exCtx),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = tokenService.issue(ik, asset, destination, request.getQuantity(), exCtx);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.ISSUE, null,
@@ -234,12 +206,8 @@ public class Controller {
         transactionHook.ifPresent(h -> h.preTransaction(
                 ik, OperationType.TRANSFER, source, destination, asset,
                 request.getQuantity(), sig, exCtx));
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "transfer", computeInputsHash("transfer", ik, request.toString()),
-                () -> tokenService.transfer(ik, request.getNonce(), source, destination, asset,
-                        request.getQuantity(), sig, exCtx),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = tokenService.transfer(ik, request.getNonce(), source, destination, asset,
+                request.getQuantity(), sig, exCtx);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.TRANSFER, source, destination, asset,
@@ -269,12 +237,8 @@ public class Controller {
         transactionHook.ifPresent(h -> h.preTransaction(
                 ik, OperationType.REDEEM, source.source(), null, asset,
                 request.getQuantity(), sig, exCtx));
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "redeem", computeInputsHash("redeem", ik, request.toString()),
-                () -> tokenService.redeem(ik, request.getNonce(), source, asset,
-                        request.getQuantity(), request.getOperationId(), sig, exCtx),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = tokenService.redeem(ik, request.getNonce(), source, asset,
+                request.getQuantity(), request.getOperationId(), sig, exCtx);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.REDEEM, source.source(), null, asset,
@@ -357,12 +321,8 @@ public class Controller {
         transactionHook.ifPresent(h -> h.preTransaction(
                 ik, OperationType.HOLD, source, destination, asset,
                 request.getQuantity(), sig, exCtx));
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "hold", computeInputsHash("hold", ik, request.toString()),
-                () -> escrowService.hold(ik, request.getNonce(), source, destination, asset,
-                        request.getQuantity(), sig, request.getOperationId(), exCtx),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = escrowService.hold(ik, request.getNonce(), source, destination, asset,
+                request.getQuantity(), sig, request.getOperationId(), exCtx);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.HOLD, source, destination, asset,
@@ -387,12 +347,8 @@ public class Controller {
         transactionHook.ifPresent(h -> h.preTransaction(
                 ik, OperationType.RELEASE, source, destination, asset,
                 request.getQuantity(), null, exCtx));
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "release", computeInputsHash("release", ik, request.toString()),
-                () -> escrowService.release(ik, source, destination, asset,
-                        request.getQuantity(), request.getOperationId(), exCtx),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = escrowService.release(ik, source, destination, asset,
+                request.getQuantity(), request.getOperationId(), exCtx);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.RELEASE, source, destination, asset,
@@ -416,12 +372,8 @@ public class Controller {
         transactionHook.ifPresent(h -> h.preTransaction(
                 ik, OperationType.ROLLBACK, source, null, asset,
                 request.getQuantity(), null, exCtx));
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "rollback", computeInputsHash("rollback", ik, request.toString()),
-                () -> escrowService.rollback(ik, source, asset,
-                        request.getQuantity(), request.getOperationId(), exCtx),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = escrowService.rollback(ik, source, asset,
+                request.getQuantity(), request.getOperationId(), exCtx);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.ROLLBACK, source, null, asset,
@@ -445,19 +397,15 @@ public class Controller {
         // if (sig != null && !signatureVerifier.verify(sig, request.getOwner().getFinId())) {
         //     throw new BusinessException(4, "Signature verification failed");
         // }
-        DepositOperation rcptOp = operationExecutor.execute(
-                "depositInstruction", computeInputsHash("depositInstruction", ik, request.toString()),
-                () -> paymentService.getDepositInstruction(
-                        ik,
-                        sourceFromAPI(request.getOwner()),
-                        destinationFromAPI(request.getDestination()),
-                        fromAPI(request.getAsset()),
-                        request.getAmount(),
-                        request.getDetails(),
-                        request.getNonce(),
-                        fromAPI(request.getSignature())
-                ),
-                cid -> new PendingDepositOperation(cid, new OperationMetadata(new PollingResponseStrategy()))
+        DepositOperation rcptOp = paymentService.getDepositInstruction(
+                ik,
+                sourceFromAPI(request.getOwner()),
+                destinationFromAPI(request.getDestination()),
+                fromAPI(request.getAsset()),
+                request.getAmount(),
+                request.getDetails(),
+                request.getNonce(),
+                fromAPI(request.getSignature())
         );
         return ResponseEntity.status(HttpStatus.OK).body(toAPIResponse(rcptOp));
     }
@@ -488,12 +436,8 @@ public class Controller {
             description = request.getPayoutInstruction().getDescription();
         }
         String desc = description;
-        ReceiptOperation rcptOp = operationExecutor.execute(
-                "payout", computeInputsHash("payout", ik, request.toString()),
-                () -> paymentService.payout(ik, source, destination, asset,
-                        request.getQuantity(), desc, request.getNonce(), sig),
-                cid -> new PendingReceiptStatus(cid, new OperationMetadata(new PollingResponseStrategy()))
-        );
+        ReceiptOperation rcptOp = paymentService.payout(ik, source, destination, asset,
+                request.getQuantity(), desc, request.getNonce(), sig);
 
         transactionHook.ifPresent(h -> h.postTransaction(
                 ik, OperationType.TRANSFER, source, destination, asset,

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/Mappers.java
@@ -2,6 +2,7 @@ package io.ownera.ledger.adapter;
 
 import io.ownera.ledger.adapter.api.model.*;
 import io.ownera.ledger.adapter.service.model.*;
+import io.ownera.ledger.adapter.service.workflow.CachedJsonOperationStatus;
 import javax.annotation.Nullable;
 
 import java.util.HashMap;
@@ -227,6 +228,14 @@ public class Mappers {
     }
 
     public static APIApproveExecutionPlanResponse toAPIResponse(PlanApprovalStatus status) {
+        APIExecutionPlanApprovalOperation cached = unwrapCachedPlan(status);
+        if (cached != null) {
+            return new APIApproveExecutionPlanResponse()
+                    .cid(cached.getCid())
+                    .isCompleted(cached.getIsCompleted())
+                    .operationMetadata(cached.getOperationMetadata())
+                    .approval(cached.getApproval());
+        }
         if (status instanceof PendingPlan) {
             PendingPlan pending = (PendingPlan) status;
             return new APIApproveExecutionPlanResponse()
@@ -310,6 +319,15 @@ public class Mappers {
     }
 
     public static APICreateAssetResponse toAPIResponse(AssetCreationStatus status) {
+        APICreateAssetOperation cached = unwrapCachedCreateAsset(status);
+        if (cached != null) {
+            return new APICreateAssetResponse()
+                    .cid(cached.getCid())
+                    .isCompleted(cached.getIsCompleted())
+                    .operationMetadata(cached.getOperationMetadata())
+                    .error(cached.getError())
+                    .response(cached.getResponse());
+        }
         APICreateAssetResponse response = new APICreateAssetResponse();
         if (status instanceof PendingAssetCreation) {
             PendingAssetCreation pending = (PendingAssetCreation) status;
@@ -379,6 +397,15 @@ public class Mappers {
     }
 
     public static APIDepositInstructionResponse toAPIResponse(DepositOperation status) {
+        APIDepositOperation cached = unwrapCachedDeposit(status);
+        if (cached != null) {
+            return new APIDepositInstructionResponse()
+                    .cid(cached.getCid())
+                    .isCompleted(cached.getIsCompleted())
+                    .operationMetadata(cached.getOperationMetadata())
+                    .error(cached.getError())
+                    .response(cached.getResponse());
+        }
         APIDepositInstructionResponse response = new APIDepositInstructionResponse();
         if (status instanceof PendingDepositOperation) {
             PendingDepositOperation pending = (PendingDepositOperation) status;
@@ -484,6 +511,8 @@ public class Mappers {
     }
 
     public static APIReceiptOperation toAPI(ReceiptOperation op) {
+        APIReceiptOperation cached = unwrapCachedReceipt(op);
+        if (cached != null) return cached;
         APIReceiptOperation operation = new APIReceiptOperation();
         if (op instanceof SuccessReceiptStatus) {
             SuccessReceiptStatus success = (SuccessReceiptStatus) op;
@@ -846,6 +875,16 @@ public class Mappers {
     // --- Payout response mapping ---
 
     public static APIPayoutResponse toAPIPayoutResponse(ReceiptOperation op) {
+        APIReceiptOperation cached = unwrapCachedReceipt(op);
+        if (cached != null) {
+            // Byte-faithful replay: APIPayoutResponse shares the same fields as APIReceiptOperation.
+            return new APIPayoutResponse()
+                    .cid(cached.getCid())
+                    .isCompleted(cached.getIsCompleted())
+                    .operationMetadata(cached.getOperationMetadata())
+                    .error(cached.getError())
+                    .response(cached.getResponse());
+        }
         APIPayoutResponse response = new APIPayoutResponse();
         if (op instanceof SuccessReceiptStatus) {
             SuccessReceiptStatus success = (SuccessReceiptStatus) op;
@@ -1091,6 +1130,53 @@ public class Mappers {
                 apiReceipt.getId(), opType, asset, source, destination,
                 apiReceipt.getQuantity(), txDetails, tradeDetails, null, timestamp);
         return new SuccessReceiptStatus(receipt);
+    }
+
+    // --- Byte-faithful cached-replay unwrappers ---
+    //
+    // The workflow proxy returns a {@link CachedJsonOperationStatus} for any existing row instead
+    // of reconstructing the internal type from stored outputs (which would lose non-roundtripping
+    // fields). The Controller's response mappers detect that marker via these helpers and emit the
+    // stored API operation directly — byte-identical to the original POST's response.
+
+    private static APIReceiptOperation unwrapCachedReceipt(ReceiptOperation op) {
+        if (!(op instanceof CachedJsonOperationStatus)) return null;
+        Object actual = ((CachedJsonOperationStatus) op).apiStatus.getActualInstance();
+        if (actual instanceof APIOperationStatusReceipt) {
+            return ((APIOperationStatusReceipt) actual).getOperation();
+        }
+        throw new MappingException("Cached outputs do not wrap a receipt operation: "
+                + (actual != null ? actual.getClass().getName() : "null"));
+    }
+
+    private static APICreateAssetOperation unwrapCachedCreateAsset(AssetCreationStatus status) {
+        if (!(status instanceof CachedJsonOperationStatus)) return null;
+        Object actual = ((CachedJsonOperationStatus) status).apiStatus.getActualInstance();
+        if (actual instanceof APIOperationStatusCreateAsset) {
+            return ((APIOperationStatusCreateAsset) actual).getOperation();
+        }
+        throw new MappingException("Cached outputs do not wrap a createAsset operation: "
+                + (actual != null ? actual.getClass().getName() : "null"));
+    }
+
+    private static APIDepositOperation unwrapCachedDeposit(DepositOperation status) {
+        if (!(status instanceof CachedJsonOperationStatus)) return null;
+        Object actual = ((CachedJsonOperationStatus) status).apiStatus.getActualInstance();
+        if (actual instanceof APIOperationStatusDeposit) {
+            return ((APIOperationStatusDeposit) actual).getOperation();
+        }
+        throw new MappingException("Cached outputs do not wrap a deposit operation: "
+                + (actual != null ? actual.getClass().getName() : "null"));
+    }
+
+    private static APIExecutionPlanApprovalOperation unwrapCachedPlan(PlanApprovalStatus status) {
+        if (!(status instanceof CachedJsonOperationStatus)) return null;
+        Object actual = ((CachedJsonOperationStatus) status).apiStatus.getActualInstance();
+        if (actual instanceof APIOperationStatusApproval) {
+            return ((APIOperationStatusApproval) actual).getOperation();
+        }
+        throw new MappingException("Cached outputs do not wrap a plan approval operation: "
+                + (actual != null ? actual.getClass().getName() : "null"));
     }
 
     private static ErrorDetails toErrorDetails(@Nullable Integer code, @Nullable String message) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/Asset.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/Asset.java
@@ -1,5 +1,6 @@
 package io.ownera.ledger.adapter.service.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import javax.annotation.Nullable;
 
 public class Asset {
@@ -12,6 +13,7 @@ public class Asset {
         this(assetId, assetType, null);
     }
 
+    @JsonCreator
     public Asset(String assetId, AssetType assetType, @Nullable LedgerAssetIdentifier ledgerIdentifier) {
         this.assetId = assetId;
         this.assetType = assetType;

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/FinIdAccount.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/FinIdAccount.java
@@ -1,5 +1,6 @@
 package io.ownera.ledger.adapter.service.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import javax.annotation.Nullable;
 
 public class FinIdAccount implements SourceAccount, DestinationAccount {
@@ -22,6 +23,7 @@ public class FinIdAccount implements SourceAccount, DestinationAccount {
         this(finId, null, null);
     }
 
+    @JsonCreator
     public FinIdAccount(String finId, @Nullable String orgId, @Nullable String custodianOrgId) {
         this.finId = finId;
         this.orgId = orgId;

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/CachedJsonOperationStatus.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/CachedJsonOperationStatus.java
@@ -1,0 +1,42 @@
+package io.ownera.ledger.adapter.service.workflow;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ownera.ledger.adapter.api.model.APIOperationStatus;
+import io.ownera.ledger.adapter.service.model.AssetCreationStatus;
+import io.ownera.ledger.adapter.service.model.DepositOperation;
+import io.ownera.ledger.adapter.service.model.PlanApprovalStatus;
+import io.ownera.ledger.adapter.service.model.ReceiptOperation;
+
+/**
+ * Marker {@link io.ownera.ledger.adapter.service.model.OperationStatus} carrying the raw stored
+ * outputs JSON for a duplicate-call short-circuit.
+ *
+ * <p>The workflow proxy returns this on a cache hit. Mappers detect it and emit the API response
+ * by unwrapping the stored {@link APIOperationStatus} directly, instead of round-tripping through
+ * the lossy internal model. That preserves byte-faithfulness with the original POST's response —
+ * fields like Receipt's {@code proof}, {@code LedgerReference}'s {@code network}/{@code standard},
+ * deposit destinations, and payment options survive the duplicate hit.
+ *
+ * <p>Mirrors Node's {@code createServiceProxy} returning {@code storageOperation.outputs}
+ * (skeleton/src/workflows/service.ts): the stored payload is the source of truth.
+ *
+ * <p>Implements all four service-method return marker interfaces so a single instance can satisfy
+ * any proxied call site (createAsset / issue / transfer / ... / approvePlan / ...).
+ */
+public final class CachedJsonOperationStatus
+        implements AssetCreationStatus, ReceiptOperation, DepositOperation, PlanApprovalStatus {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    public final String rawJson;
+    public final APIOperationStatus apiStatus;
+
+    public CachedJsonOperationStatus(String rawJson) {
+        this.rawJson = rawJson;
+        try {
+            this.apiStatus = MAPPER.readValue(rawJson, APIOperationStatus.class);
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot parse stored outputs JSON for cached replay", e);
+        }
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
@@ -14,6 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Database-backed implementation of {@link OperationStore}.
@@ -55,12 +57,15 @@ public class DbOperationStore implements OperationStore {
     }
 
     @Override
-    public void save(OperationRecord record, @Nullable String pendingOutputsJson) {
+    public void save(OperationRecord record, @Nullable String inputsJson, @Nullable String pendingOutputsJson) {
         var insert = dsl.insertInto(table)
                 .set(CID, record.cid)
                 .set(METHOD, record.method)
                 .set(STATUS, record.status.name())
                 .set(INPUTS_HASH, record.inputsHash);
+        if (inputsJson != null) {
+            insert = insert.set(INPUTS, JSONB.valueOf(inputsJson));
+        }
         if (pendingOutputsJson != null) {
             insert = insert.set(OUTPUTS, JSONB.valueOf(pendingOutputsJson));
         }
@@ -101,6 +106,22 @@ public class DbOperationStore implements OperationStore {
                 .where(CID.eq(cid))
                 .fetchOne(OUTPUTS);
         return row != null ? row.data() : null;
+    }
+
+    @Override
+    public List<PendingOperation> findPending(String method) {
+        return dsl.select(CID, METHOD, INPUTS)
+                .from(table)
+                .where(METHOD.eq(method))
+                .and(STATUS.eq(OperationRecord.Status.IN_PROGRESS.name()))
+                .fetch()
+                .stream()
+                .map(r -> {
+                    JSONB inputs = r.get(INPUTS);
+                    return new PendingOperation(r.get(CID), r.get(METHOD),
+                            inputs != null ? inputs.data() : null);
+                })
+                .collect(Collectors.toList());
     }
 
     private OperationRecord toRecord(org.jooq.Record r) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/DbOperationStore.java
@@ -58,7 +58,25 @@ public class DbOperationStore implements OperationStore {
 
     @Override
     public void save(OperationRecord record, @Nullable String inputsJson, @Nullable String pendingOutputsJson) {
-        var insert = dsl.insertInto(table)
+        buildInsert(record, inputsJson, pendingOutputsJson).execute();
+    }
+
+    @Override
+    public boolean tryInsert(OperationRecord record, @Nullable String inputsJson, @Nullable String pendingOutputsJson) {
+        // ON CONFLICT (inputs_hash) DO NOTHING returns 0 affected rows when the row already
+        // exists, 1 when we actually inserted. This is the atomic guarantee that two concurrent
+        // identical requests don't both blow up on the unique constraint.
+        int affected = buildInsert(record, inputsJson, pendingOutputsJson)
+                .onConflict(INPUTS_HASH)
+                .doNothing()
+                .execute();
+        return affected == 1;
+    }
+
+    private org.jooq.InsertSetMoreStep<?> buildInsert(OperationRecord record,
+                                                      @Nullable String inputsJson,
+                                                      @Nullable String pendingOutputsJson) {
+        org.jooq.InsertSetMoreStep<?> insert = dsl.insertInto(table)
                 .set(CID, record.cid)
                 .set(METHOD, record.method)
                 .set(STATUS, record.status.name())
@@ -69,7 +87,7 @@ public class DbOperationStore implements OperationStore {
         if (pendingOutputsJson != null) {
             insert = insert.set(OUTPUTS, JSONB.valueOf(pendingOutputsJson));
         }
-        insert.execute();
+        return insert;
     }
 
     @Override

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
@@ -23,6 +23,17 @@ public interface OperationStore {
     void save(OperationRecord record, @Nullable String inputsJson, @Nullable String pendingOutputsJson);
 
     /**
+     * Atomic insert-or-noop on the unique {@code inputs_hash} key. Returns {@code true} if this
+     * call inserted the row, {@code false} if the row already existed (and the caller lost the
+     * race).
+     *
+     * <p>Mirrors Node's {@code saveOperation(...)} (skeleton/src/workflows/storage.ts): two
+     * concurrent identical requests must not collide on the unique constraint — the loser must
+     * be able to read the winner's persisted outputs and return them instead of erroring.
+     */
+    boolean tryInsert(OperationRecord record, @Nullable String inputsJson, @Nullable String pendingOutputsJson);
+
+    /**
      * Backward-compatible overload: no inputs to persist.
      */
     default void save(OperationRecord record, @Nullable String pendingOutputsJson) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/OperationStore.java
@@ -2,6 +2,7 @@ package io.ownera.ledger.adapter.service.workflow;
 
 import io.ownera.ledger.adapter.service.model.OperationStatus;
 import javax.annotation.Nullable;
+import java.util.List;
 
 public interface OperationStore {
 
@@ -9,14 +10,24 @@ public interface OperationStore {
     OperationRecord findByInputsHash(String inputsHash);
 
     /**
-     * Persist a new operation row with optional pending-payload JSON.
+     * Persist a new operation row with optional inputs and pending-payload JSON.
      *
-     * <p>Mirrors the Node skeleton's {@code createServiceProxy} contract: every known CID has a
-     * pollable payload from the moment it is created — pending while the operation is in flight,
-     * then success/failure once it finalizes. Passing {@code null} leaves the {@code outputs}
-     * column unset (useful for callers that have no payload to persist yet).
+     * <p>{@code inputsJson} is the serialized method-argument tuple used by the workflow proxy
+     * for crash recovery (replay of {@code IN_PROGRESS} operations after restart). Pass
+     * {@code null} when the caller does not own a re-invokable representation of its args.
+     *
+     * <p>{@code pendingOutputsJson} mirrors the Node skeleton's {@code createServiceProxy}
+     * contract: every known CID has a pollable payload from the moment it is created — pending
+     * while the operation is in flight, then success/failure once it finalizes.
      */
-    void save(OperationRecord record, @Nullable String pendingOutputsJson);
+    void save(OperationRecord record, @Nullable String inputsJson, @Nullable String pendingOutputsJson);
+
+    /**
+     * Backward-compatible overload: no inputs to persist.
+     */
+    default void save(OperationRecord record, @Nullable String pendingOutputsJson) {
+        save(record, null, pendingOutputsJson);
+    }
 
     /**
      * Backward-compatible overload that persists no pending payload. New callers should pass
@@ -24,7 +35,7 @@ public interface OperationStore {
      * polling endpoint can return an in-progress payload for the cid.
      */
     default void save(OperationRecord record) {
-        save(record, null);
+        save(record, null, null);
     }
 
     /**
@@ -58,4 +69,29 @@ public interface OperationStore {
      */
     @Nullable
     String findOutputsByCid(String cid);
+
+    /**
+     * Fetch all {@code IN_PROGRESS} operations for a method, with their persisted input JSON.
+     *
+     * <p>Used by {@link WorkflowRecovery} at startup to replay operations that were left
+     * in-flight when the process crashed. Mirrors Node's
+     * {@code storage.getPendingOperations(method)} in {@code skeleton/src/workflows/storage.ts}.
+     */
+    List<PendingOperation> findPending(String method);
+
+    /**
+     * Row shape returned by {@link #findPending(String)}: the cid + persisted input args JSON
+     * needed to re-invoke the original service method.
+     */
+    final class PendingOperation {
+        public final String cid;
+        public final String method;
+        public final @Nullable String inputsJson;
+
+        public PendingOperation(String cid, String method, @Nullable String inputsJson) {
+            this.cid = cid;
+            this.method = method;
+            this.inputsJson = inputsJson;
+        }
+    }
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowArgsCodec.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowArgsCodec.java
@@ -1,0 +1,70 @@
+package io.ownera.ledger.adapter.service.workflow;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.cfg.ConstructorDetector;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.module.paramnames.ParameterNamesModule;
+
+/**
+ * Serializes method-argument tuples to JSON (for {@code operations.inputs} persistence) and
+ * deserializes them back on crash recovery.
+ *
+ * <p>Default typing is enabled so polymorphic argument types (e.g. {@code Source}/{@code Destination}
+ * via {@code SourceAccount}/{@code DestinationAccount} sub-interfaces, {@code AssetBind} variants)
+ * round-trip with their concrete class names. The validator is {@code LaissezFaireSubTypeValidator}
+ * because the JSON is only ever read back from our own database — there is no untrusted-input
+ * threat model.
+ *
+ * <p>Field-based access mirrors the rest of the skeleton's models, which expose {@code public final}
+ * fields rather than getters.
+ */
+public class WorkflowArgsCodec {
+
+    private final ObjectMapper mapper;
+
+    public WorkflowArgsCodec() {
+        this(buildMapper());
+    }
+
+    public WorkflowArgsCodec(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    private static ObjectMapper buildMapper() {
+        ObjectMapper m = new ObjectMapper();
+        // jackson-module-parameter-names lets us deserialize immutable POJOs (public final fields
+        // + single all-args constructor, no @JsonCreator) provided the skeleton is compiled with
+        // `-parameters` so constructor parameter names survive into bytecode. Register explicitly
+        // (auto-discovery via findAndRegisterModules() turned out not to wire it in this setup).
+        m.registerModule(new ParameterNamesModule());
+        // When a class has multiple constructors (e.g. {@code Asset} has a 2-arg overload that
+        // delegates to the canonical 3-arg one), Jackson by default refuses to pick. Force it to
+        // prefer the canonical (largest-arity) constructor for property-based binding.
+        m.setConstructorDetector(ConstructorDetector.USE_PROPERTIES_BASED);
+        m.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        m.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY);
+        m.activateDefaultTyping(LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL);
+        m.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return m;
+    }
+
+    public String encode(Object[] args) {
+        try {
+            return mapper.writeValueAsString(args);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to serialize workflow args", e);
+        }
+    }
+
+    public Object[] decode(String json) {
+        try {
+            return mapper.readValue(json, Object[].class);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to deserialize workflow args", e);
+        }
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowOutcomes.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowOutcomes.java
@@ -4,20 +4,50 @@ import io.ownera.ledger.adapter.service.model.ErrorDetails;
 import io.ownera.ledger.adapter.service.model.FailedAssetCreation;
 import io.ownera.ledger.adapter.service.model.FailedDepositOperation;
 import io.ownera.ledger.adapter.service.model.FailedReceiptStatus;
+import io.ownera.ledger.adapter.service.model.OperationMetadata;
 import io.ownera.ledger.adapter.service.model.OperationStatus;
+import io.ownera.ledger.adapter.service.model.PendingAssetCreation;
+import io.ownera.ledger.adapter.service.model.PendingDepositOperation;
+import io.ownera.ledger.adapter.service.model.PendingPlan;
+import io.ownera.ledger.adapter.service.model.PendingReceiptStatus;
 import io.ownera.ledger.adapter.service.model.RejectedPlan;
 
 /**
- * Maps method names to their failure {@link OperationStatus} variants.
+ * Maps method names to their pending / failure {@link OperationStatus} variants.
  *
  * <p>Mirrors the Node skeleton's {@code wrappedResponse} switch
  * (skeleton/src/workflows/service.ts): each proxied method has both a pending and a failure
- * variant of the same status type. The executor uses this to persist a failure payload so the
- * polling endpoint can return a proper failed-operation response instead of 404.
+ * variant of the same status type. The workflow proxy uses this to build placeholders and
+ * failure payloads without per-call lambdas.
  */
 public final class WorkflowOutcomes {
 
     private WorkflowOutcomes() {}
+
+    public static OperationStatus pendingFor(String method, String cid, OperationMetadata metadata) {
+        switch (method) {
+            case "createAsset":
+                return new PendingAssetCreation(cid, metadata);
+            case "issue":
+            case "transfer":
+            case "redeem":
+            case "hold":
+            case "release":
+            case "rollback":
+            case "payout":
+                return new PendingReceiptStatus(cid, metadata);
+            case "approvePlan":
+            case "proposeCancelPlan":
+            case "proposeResetPlan":
+            case "proposeInstructionApproval":
+                return new PendingPlan(cid, metadata);
+            case "depositInstruction":
+                return new PendingDepositOperation(cid, metadata);
+            default:
+                throw new IllegalArgumentException(
+                        "Unknown method '" + method + "' — add it to WorkflowOutcomes.pendingFor()");
+        }
+    }
 
     public static OperationStatus failureFor(String method, int code, String message) {
         ErrorDetails details = new ErrorDetails(code, message);

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowOutcomes.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowOutcomes.java
@@ -41,7 +41,8 @@ public final class WorkflowOutcomes {
             case "proposeResetPlan":
             case "proposeInstructionApproval":
                 return new PendingPlan(cid, metadata);
-            case "depositInstruction":
+            case "depositInstruction":      // legacy method-name string (sync OperationExecutor)
+            case "getDepositInstruction":   // interface method name used by the workflow proxy
                 return new PendingDepositOperation(cid, metadata);
             default:
                 throw new IllegalArgumentException(
@@ -68,6 +69,7 @@ public final class WorkflowOutcomes {
             case "proposeInstructionApproval":
                 return new RejectedPlan(details);
             case "depositInstruction":
+            case "getDepositInstruction":
                 return new FailedDepositOperation(details);
             default:
                 throw new IllegalArgumentException(

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowRecovery.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowRecovery.java
@@ -1,0 +1,60 @@
+package io.ownera.ledger.adapter.service.workflow;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * Startup hook that replays {@code IN_PROGRESS} operations through a {@link WorkflowServiceProxy}.
+ *
+ * <p>Mirrors the Node skeleton's recovery step in {@code createServiceProxy}: after migrations
+ * land, the proxy iterates proxied methods, fetches each method's pending operations from
+ * storage, and re-invokes them via {@code executeAndFinalize}. A crash mid-flight no longer
+ * leaves an operation stuck in {@code IN_PROGRESS} — it will be re-driven to {@code COMPLETED}
+ * or {@code FAILED} after restart.
+ *
+ * <p>Wiring: the adapter calls {@link #replayAll()} once during application startup after the
+ * data source / schema are ready. In Spring this can be an
+ * {@code ApplicationReadyEvent} listener.
+ */
+public class WorkflowRecovery {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkflowRecovery.class);
+
+    private final OperationStore store;
+    private final WorkflowServiceProxy proxy;
+    private final List<String> proxiedMethods;
+    private final WorkflowArgsCodec argsCodec;
+
+    public WorkflowRecovery(OperationStore store,
+                            WorkflowServiceProxy proxy,
+                            List<String> proxiedMethods,
+                            WorkflowArgsCodec argsCodec) {
+        this.store = store;
+        this.proxy = proxy;
+        this.proxiedMethods = proxiedMethods;
+        this.argsCodec = argsCodec;
+    }
+
+    public void replayAll() {
+        for (String method : proxiedMethods) {
+            List<OperationStore.PendingOperation> pending = store.findPending(method);
+            if (pending.isEmpty()) continue;
+            logger.info("Replaying {} pending operation(s) for method={}", pending.size(), method);
+            for (OperationStore.PendingOperation op : pending) {
+                if (op.inputsJson == null) {
+                    logger.warn("Skipping replay for cid={} method={}: no persisted inputs (was the row written by a pre-PR1 build?)",
+                            op.cid, method);
+                    continue;
+                }
+                try {
+                    Object[] args = argsCodec.decode(op.inputsJson);
+                    proxy.replay(op.cid, args);
+                } catch (Exception e) {
+                    logger.error("Failed to decode inputs for cid={} method={}: {}", op.cid, method, e.getMessage(), e);
+                }
+            }
+        }
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
@@ -1,0 +1,225 @@
+package io.ownera.ledger.adapter.service.workflow;
+
+import io.ownera.ledger.adapter.service.model.CallbackResponseStrategy;
+import io.ownera.ledger.adapter.service.model.OperationMetadata;
+import io.ownera.ledger.adapter.service.model.OperationStatus;
+import io.ownera.ledger.adapter.service.model.PollingResponseStrategy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * JDK dynamic proxy that adds durable async workflow semantics around a service interface.
+ *
+ * <p>Mirrors the Node skeleton's {@code createServiceProxy}
+ * (skeleton/src/workflows/service.ts): when a proxied method is invoked, the proxy persists a
+ * pending row (with serialized input args + pending output payload), submits the real method
+ * to a background executor, and returns the pending payload immediately. When the real method
+ * completes, {@link #finalize} writes the result to the store first and only then sends a
+ * callback — so a crash between persistence and callback never drops a finalized operation
+ * (it stays in the row; startup replay re-finalizes it).
+ *
+ * <p>Idempotency: each call hashes (method, encoded args) into an {@code inputs_hash}. A
+ * second identical call short-circuits to the existing row's outputs without re-running the
+ * underlying service method.
+ *
+ * <p>Crash recovery is handled by {@link WorkflowRecovery}, which replays {@code IN_PROGRESS}
+ * rows through the proxy's {@link #replay(String, Object[])} entrypoint at startup.
+ */
+public class WorkflowServiceProxy {
+
+    private static final Logger logger = LoggerFactory.getLogger(WorkflowServiceProxy.class);
+
+    private final Object target;
+    private final OperationStore store;
+    private final @Nullable CallbackClient callbackClient;
+    private final ExecutorService executor;
+    private final WorkflowArgsCodec argsCodec;
+    private final OperationOutputSerializer outputSerializer;
+    private final Set<String> proxiedMethods;
+    private final OperationMetadata opMetadata;
+
+    public WorkflowServiceProxy(Object target,
+                                OperationStore store,
+                                @Nullable CallbackClient callbackClient,
+                                ExecutorService executor,
+                                WorkflowArgsCodec argsCodec,
+                                OperationOutputSerializer outputSerializer,
+                                Set<String> proxiedMethods) {
+        this.target = target;
+        this.store = store;
+        this.callbackClient = callbackClient;
+        this.executor = executor;
+        this.argsCodec = argsCodec;
+        this.outputSerializer = outputSerializer;
+        this.proxiedMethods = proxiedMethods;
+        // Match Node: when a callback client is wired, advertise callback strategy in pending
+        // payloads so the router knows not to poll.
+        this.opMetadata = new OperationMetadata(
+                callbackClient != null ? new CallbackResponseStrategy() : new PollingResponseStrategy());
+    }
+
+    /** Wrap {@code target} in a JDK dynamic proxy that implements {@code iface}. */
+    @SuppressWarnings("unchecked")
+    public <T> T asProxy(Class<T> iface) {
+        return (T) Proxy.newProxyInstance(
+                iface.getClassLoader(),
+                new Class<?>[]{iface},
+                new ProxyInvocationHandler(this));
+    }
+
+    /** Convenience: construct + asProxy in one call. */
+    public static <T> T wrap(Class<T> iface,
+                             T target,
+                             OperationStore store,
+                             @Nullable CallbackClient callbackClient,
+                             ExecutorService executor,
+                             WorkflowArgsCodec argsCodec,
+                             OperationOutputSerializer outputSerializer,
+                             Set<String> proxiedMethods) {
+        return new WorkflowServiceProxy(target, store, callbackClient, executor, argsCodec,
+                outputSerializer, proxiedMethods).asProxy(iface);
+    }
+
+    /**
+     * Re-run a previously-persisted invocation. Called by {@link WorkflowRecovery} at startup
+     * for each {@code IN_PROGRESS} row, so a crashed-mid-flight operation eventually reaches
+     * {@code COMPLETED} or {@code FAILED} and unblocks any waiting caller / callback.
+     */
+    public void replay(String cid, Object[] args) {
+        Method method = findProxiedMethod(cid);
+        if (method == null) return;
+        executor.submit(() -> executeAndFinalize(method, args, cid));
+    }
+
+    private @Nullable Method findProxiedMethod(String cid) {
+        OperationRecord rec = store.findByCid(cid);
+        if (rec == null) {
+            logger.warn("Replay requested for unknown cid={}", cid);
+            return null;
+        }
+        for (Method m : target.getClass().getMethods()) {
+            if (proxiedMethods.contains(m.getName()) && m.getName().equals(rec.method)) {
+                return m;
+            }
+        }
+        logger.warn("Replay: no proxied method named '{}' on target {}", rec.method, target.getClass());
+        return null;
+    }
+
+    Object invokeProxied(Method method, Object[] args) {
+        String methodName = method.getName();
+        String inputsJson = argsCodec.encode(args == null ? new Object[0] : args);
+        String inputsHash = OperationExecutor.computeInputsHash(methodName, inputsJson);
+
+        OperationRecord existing = store.findByInputsHash(inputsHash);
+        if (existing != null) {
+            if (existing.status == OperationRecord.Status.COMPLETED && existing.result != null) {
+                logger.debug("Returning cached completed result for method={}, cid={}", methodName, existing.cid);
+                return existing.result;
+            }
+            // In-flight or failed-without-result: return the pending placeholder built for this
+            // method so the caller can poll. Matches Node behavior: the row is the source of truth.
+            logger.debug("Returning pending placeholder (existing row) for method={}, cid={}", methodName, existing.cid);
+            return WorkflowOutcomes.pendingFor(methodName, existing.cid, opMetadata);
+        }
+
+        String cid = CorrelationIdGenerator.generate();
+        OperationStatus pending = WorkflowOutcomes.pendingFor(methodName, cid, opMetadata);
+        String pendingJson = trySerialize(pending, methodName, cid);
+
+        OperationRecord record = new OperationRecord(
+                cid, methodName, OperationRecord.Status.IN_PROGRESS, inputsHash, null);
+        store.save(record, inputsJson, pendingJson);
+
+        // Fire-and-forget background execution; finalize handles success + failure paths.
+        Object[] argsCopy = args == null ? new Object[0] : args.clone();
+        executor.submit(() -> executeAndFinalize(method, argsCopy, cid));
+        return pending;
+    }
+
+    private void executeAndFinalize(Method method, Object[] args, String cid) {
+        OperationStatus outcome;
+        OperationRecord.Status dbStatus;
+        try {
+            // setAccessible: the interface method is public, but the target may live in a
+            // package-private class (common in tests, and possible in production); without
+            // this, reflection enforces visibility on the declaring class and refuses.
+            method.setAccessible(true);
+            outcome = (OperationStatus) method.invoke(target, args);
+            dbStatus = OperationRecord.Status.COMPLETED;
+        } catch (InvocationTargetException e) {
+            Throwable cause = e.getCause() != null ? e.getCause() : e;
+            logger.error("Operation failed: method={}, cid={}, error={}", method.getName(), cid, cause.getMessage());
+            outcome = WorkflowOutcomes.failureFor(method.getName(), 1, String.valueOf(cause.getMessage()));
+            dbStatus = OperationRecord.Status.FAILED;
+        } catch (Exception e) {
+            logger.error("Reflective invoke failed: method={}, cid={}, error={}", method.getName(), cid, e.getMessage());
+            outcome = WorkflowOutcomes.failureFor(method.getName(), 1, String.valueOf(e.getMessage()));
+            dbStatus = OperationRecord.Status.FAILED;
+        }
+        finalize(cid, dbStatus, outcome);
+    }
+
+    /**
+     * Persist the outcome, then send the callback. The order matters: a crash between persist
+     * and callback leaves a {@code COMPLETED}/{@code FAILED} row that a future poll can read,
+     * and the next callback attempt comes from a re-finalization on startup, not from a
+     * silently-dropped success.
+     */
+    void finalize(String cid, OperationRecord.Status dbStatus, OperationStatus outcome) {
+        String outcomeJson = trySerialize(outcome, "<finalize>", cid);
+        try {
+            store.updateStatus(cid, dbStatus, outcomeJson);
+        } catch (Exception e) {
+            logger.error("Failed to persist outcome for cid={} — skipping callback so restart can retry: {}",
+                    cid, e.getMessage());
+            return;
+        }
+        if (callbackClient != null) {
+            try {
+                callbackClient.sendCallback(cid, outcome);
+            } catch (Exception e) {
+                logger.warn("Callback failed for cid={}: {}", cid, e.getMessage());
+            }
+        }
+    }
+
+    private String trySerialize(OperationStatus status, String method, String cid) {
+        try {
+            return outputSerializer.serialize(status);
+        } catch (Exception e) {
+            logger.warn("Failed to serialize outputs for method={}, cid={}: {}", method, cid, e.getMessage());
+            return null;
+        }
+    }
+
+    private static final class ProxyInvocationHandler implements InvocationHandler {
+        private final WorkflowServiceProxy proxy;
+
+        ProxyInvocationHandler(WorkflowServiceProxy proxy) {
+            this.proxy = proxy;
+        }
+
+        @Override
+        public Object invoke(Object proxyInstance, Method method, Object[] args) throws Throwable {
+            if (proxy.proxiedMethods.contains(method.getName())) {
+                return proxy.invokeProxied(method, args);
+            }
+            // Pass-through for non-proxied methods (e.g. balance queries, proposalStatus).
+            try {
+                method.setAccessible(true);
+                return method.invoke(proxy.target, args);
+            } catch (InvocationTargetException e) {
+                throw e.getCause() != null ? e.getCause() : e;
+            }
+        }
+    }
+}

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
@@ -158,13 +158,19 @@ public class WorkflowServiceProxy {
     }
 
     private Object resolveExisting(String methodName, OperationRecord existing) {
-        if (existing.status == OperationRecord.Status.COMPLETED && existing.result != null) {
-            logger.debug("Returning cached completed result for method={}, cid={}", methodName, existing.cid);
+        // Mirror Node's createServiceProxy: "if (!inserted) return storageOperation.outputs" —
+        // return whatever payload is persisted for the row regardless of status. A COMPLETED row
+        // returns success, FAILED returns the failure payload, IN_PROGRESS returns the pending
+        // payload persisted at insert time. Only fall back to building a fresh pending
+        // placeholder when result is null (row created before outputs were persisted, or the
+        // outputs JSON failed to parse — see DbOperationStore.toRecord's best-effort decode).
+        if (existing.result != null) {
+            logger.debug("Returning persisted {} result for method={}, cid={}",
+                    existing.status, methodName, existing.cid);
             return existing.result;
         }
-        // In-flight or failed-without-result: hand back a pending placeholder so the caller can
-        // poll. Matches Node: the row is the source of truth for status, the response shape is
-        // built from the persisted outputs once finalization completes.
+        logger.debug("Existing row has no decoded result; returning fresh pending placeholder for method={}, cid={}",
+                methodName, existing.cid);
         return WorkflowOutcomes.pendingFor(methodName, existing.cid, opMetadata);
     }
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
@@ -119,16 +119,11 @@ public class WorkflowServiceProxy {
         String inputsJson = argsCodec.encode(args == null ? new Object[0] : args);
         String inputsHash = OperationExecutor.computeInputsHash(methodName, inputsJson);
 
+        // Optimistic fast-path: most duplicate calls are spread far enough apart in time that the
+        // row already exists when the second arrives. Skip the insert attempt in that case.
         OperationRecord existing = store.findByInputsHash(inputsHash);
         if (existing != null) {
-            if (existing.status == OperationRecord.Status.COMPLETED && existing.result != null) {
-                logger.debug("Returning cached completed result for method={}, cid={}", methodName, existing.cid);
-                return existing.result;
-            }
-            // In-flight or failed-without-result: return the pending placeholder built for this
-            // method so the caller can poll. Matches Node behavior: the row is the source of truth.
-            logger.debug("Returning pending placeholder (existing row) for method={}, cid={}", methodName, existing.cid);
-            return WorkflowOutcomes.pendingFor(methodName, existing.cid, opMetadata);
+            return resolveExisting(methodName, existing);
         }
 
         String cid = CorrelationIdGenerator.generate();
@@ -137,12 +132,40 @@ public class WorkflowServiceProxy {
 
         OperationRecord record = new OperationRecord(
                 cid, methodName, OperationRecord.Status.IN_PROGRESS, inputsHash, null);
-        store.save(record, inputsJson, pendingJson);
 
-        // Fire-and-forget background execution; finalize handles success + failure paths.
+        // Race-safe insert: ON CONFLICT (inputs_hash) DO NOTHING. If we lose to a concurrent
+        // identical call, tryInsert returns false and we read the winner's row instead of
+        // bubbling a unique-constraint violation up to the caller. Mirrors Node's saveOperation
+        // returning (op, inserted) from skeleton/src/workflows/storage.ts.
+        boolean inserted = store.tryInsert(record, inputsJson, pendingJson);
+        if (!inserted) {
+            OperationRecord winner = store.findByInputsHash(inputsHash);
+            if (winner != null) {
+                logger.debug("Lost insert race for method={}; returning winner's outputs cid={}",
+                        methodName, winner.cid);
+                return resolveExisting(methodName, winner);
+            }
+            // Should not happen: the conflict said the row exists, but lookup found nothing.
+            // Fall through to pending so the caller has something pollable.
+            logger.warn("tryInsert reported conflict but findByInputsHash returned null for method={}", methodName);
+            return pending;
+        }
+
+        // Won the race — kick off background work.
         Object[] argsCopy = args == null ? new Object[0] : args.clone();
         executor.submit(() -> executeAndFinalize(method, argsCopy, cid));
         return pending;
+    }
+
+    private Object resolveExisting(String methodName, OperationRecord existing) {
+        if (existing.status == OperationRecord.Status.COMPLETED && existing.result != null) {
+            logger.debug("Returning cached completed result for method={}, cid={}", methodName, existing.cid);
+            return existing.result;
+        }
+        // In-flight or failed-without-result: hand back a pending placeholder so the caller can
+        // poll. Matches Node: the row is the source of truth for status, the response shape is
+        // built from the persisted outputs once finalization completes.
+        return WorkflowOutcomes.pendingFor(methodName, existing.cid, opMetadata);
     }
 
     private void executeAndFinalize(Method method, Object[] args, String cid) {

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/workflow/WorkflowServiceProxy.java
@@ -159,18 +159,25 @@ public class WorkflowServiceProxy {
 
     private Object resolveExisting(String methodName, OperationRecord existing) {
         // Mirror Node's createServiceProxy: "if (!inserted) return storageOperation.outputs" —
-        // return whatever payload is persisted for the row regardless of status. A COMPLETED row
-        // returns success, FAILED returns the failure payload, IN_PROGRESS returns the pending
-        // payload persisted at insert time. Only fall back to building a fresh pending
-        // placeholder when result is null (row created before outputs were persisted, or the
-        // outputs JSON failed to parse — see DbOperationStore.toRecord's best-effort decode).
+        // return whatever payload is persisted for the row, byte-faithfully. Wrapping the stored
+        // JSON in CachedJsonOperationStatus lets the API mappers emit the original bytes instead
+        // of round-tripping through the internal model (which drops fields like Receipt.proof,
+        // LedgerReference.network/standard, deposit destination, etc.).
+        String outputsJson = store.findOutputsByCid(existing.cid);
+        if (outputsJson != null && !outputsJson.isEmpty()) {
+            try {
+                logger.debug("Returning byte-faithful cached outputs for method={}, cid={}, status={}",
+                        methodName, existing.cid, existing.status);
+                return new CachedJsonOperationStatus(outputsJson);
+            } catch (Exception e) {
+                logger.warn("Failed to wrap cached outputs JSON for cid={}: {}", existing.cid, e.getMessage());
+            }
+        }
+        // Fallback: stored outputs missing or unparseable. Best-effort: return the reconstructed
+        // internal result if present, else a fresh pending placeholder so callers can poll.
         if (existing.result != null) {
-            logger.debug("Returning persisted {} result for method={}, cid={}",
-                    existing.status, methodName, existing.cid);
             return existing.result;
         }
-        logger.debug("Existing row has no decoded result; returning fresh pending placeholder for method={}, cid={}",
-                methodName, existing.cid);
         return WorkflowOutcomes.pendingFor(methodName, existing.cid, opMetadata);
     }
 


### PR DESCRIPTION
## Summary

Adds the durable async workflow path to the Java skeleton, matching Node's `createServiceProxy` (`finp2p-nodejs-skeleton-adapter/skeleton/src/workflows/service.ts`). The sample-adapter is now wired through the proxy end-to-end.

This is PR 1 of the multi-PR parity plan; PR 0 (#48) landed the workflow correctness fix this builds on.

## What's in

**Infrastructure (commit 1):**
- \`OperationStore.save(record, inputsJson, pendingOutputsJson)\` overload + \`findPending(method)\` for crash recovery.
- \`WorkflowArgsCodec\` — Jackson serialization of \`Object[]\` argument tuples with default typing + \`ParameterNamesModule\`. Round-trips immutable POJOs (public final fields + canonical constructor); two model classes (\`Asset\`, \`FinIdAccount\`) get \`@JsonCreator\` to disambiguate constructor overloads.
- \`WorkflowServiceProxy\` — JDK dynamic proxy that, on a proxied method:
  - persists a row with \`IN_PROGRESS\` status + serialized inputs + pending placeholder;
  - returns the pending placeholder to the caller immediately;
  - runs the real method in a background executor and finalizes (write outputs, then fire callback).
  - Idempotent: identical inputs short-circuit to the existing row's outputs.
- \`WorkflowRecovery\` — at \`ApplicationReadyEvent\`, fetches each proxied method's \`IN_PROGRESS\` rows, decodes inputs, and re-drives them through the proxy.
- Build: \`-parameters\` compile flag + \`jackson-module-parameter-names\` dep.

**Wiring (commit 2):**
- \`WorkflowProxyConfig\` exposes \`TokenService\` / \`EscrowService\` / \`PaymentService\` / \`PlanApprovalService\` as proxy-wrapped beans + \`ExecutorService\`, \`WorkflowArgsCodec\`, recovery hook.
- \`Controller\` no longer calls \`operationExecutor.execute(...)\` — the proxy owns the workflow lifecycle. Endpoints just call the service. Removed the now-unused \`OperationExecutor\` constructor parameter and imports.
- \`Adapter.java\` and \`PostgresConfiguration.java\` drop the inline service bean methods (replaced by proxy versions in \`WorkflowProxyConfig\`).
- \`TestHelpers\` polls \`/api/operations/status/{cid}\` after Pending responses, preserving the sync-style assertions in the existing test suite.

\`OperationExecutor\` (sync path) is retained in the skeleton for adapters that prefer it over the proxy.

## What's out (deferred)

- Idempotency of replayed work depends on the underlying service honoring its idempotency key; this PR doesn't add anything beyond what the underlying services already do.
- Test isolation: each Spring context's recovery hook will pick up any IN_PROGRESS rows visible in the shared Postgres container. None show up across the current suite (all 59 tests pass deterministically); if it becomes flaky later we can add a recovery-disable property for tests.

## Tests

**6 new** (\`WorkflowServiceProxyTest\`):
- proxyReturnsPendingImmediatelyAndPersistsRow
- proxyFinalizesSuccessAndCallsCallback
- proxyFinalizesFailureAndCallsCallback
- duplicateCallShortCircuitsToExistingOutputs
- nonProxiedMethodPassesThrough
- recoveryReplaysPendingRowsAfterRestart

**53 existing** tests pass unchanged — TestHelpers absorbs the Pending → polled-completion conversion so abstract test classes (\`AbstractTokenLifecycleTest\` etc.) need no edits.

## Test plan

- [ ] CI: build + tests
- [ ] CodeQL: java-kotlin analyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)