### PR TITLE
PR 2: vanilla-service module (per-investor ledger)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
 
     <modules>
         <module>skeleton</module>
+        <module>vanilla-service</module>
         <module>sample-adapter</module>
     </modules>
 

--- a/vanilla-service/pom.xml
+++ b/vanilla-service/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.ownera</groupId>
+        <artifactId>finp2p-java-skeleton-adapter-parent</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>finp2p-java-vanilla-service</artifactId>
+
+    <properties>
+        <!-- Published as its own artifact so adapters can pick it up independently. -->
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.ownera</groupId>
+            <artifactId>finp2p-java-skeleton-adapter</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+            <version>${jooq.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>javax.annotation</groupId>
+            <artifactId>javax.annotation-api</artifactId>
+            <version>1.3.2</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+
+        <!-- Test -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>postgresql</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.flywaydb</groupId>
+            <artifactId>flyway-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/AssetDelegate.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/AssetDelegate.java
@@ -1,0 +1,26 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.model.AssetBind;
+import io.ownera.ledger.adapter.service.model.AssetCreationResult;
+import io.ownera.ledger.adapter.service.model.AssetDenomination;
+
+import javax.annotation.Nullable;
+
+/**
+ * Optional delegate for asset creation. When provided, {@code VanillaServiceImpl.createAsset}
+ * calls the delegate instead of generating a local tokenId, so adapters that need to mint
+ * on an external chain can route through here.
+ *
+ * <p>Mirrors Node's {@code AssetDelegate} interface in {@code vanilla-service/src/interfaces.ts}.
+ */
+public interface AssetDelegate {
+
+    AssetCreationResult createAsset(
+            String idempotencyKey,
+            String assetId,
+            @Nullable AssetBind assetBind,
+            @Nullable Object assetMetadata,
+            @Nullable String assetName,
+            @Nullable String issuerId,
+            @Nullable AssetDenomination assetDenomination);
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DelegateResult.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DelegateResult.java
@@ -1,0 +1,35 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import javax.annotation.Nullable;
+
+/**
+ * Result of a delegate operation. Either a success carrying an external transaction id, or a
+ * failure carrying an error message.
+ *
+ * <p>Pending / async results are intentionally unsupported — the delegate must complete its
+ * external work synchronously before returning, so the vanilla service can decide whether to
+ * commit or roll back the local DB safeguards (locks, etc.).
+ *
+ * <p>Mirrors Node's {@code DelegateResult} union in
+ * {@code vanilla-service/src/interfaces.ts}.
+ */
+public final class DelegateResult {
+
+    public final boolean success;
+    public final @Nullable String transactionId;
+    public final @Nullable String error;
+
+    private DelegateResult(boolean success, @Nullable String transactionId, @Nullable String error) {
+        this.success = success;
+        this.transactionId = transactionId;
+        this.error = error;
+    }
+
+    public static DelegateResult success(String transactionId) {
+        return new DelegateResult(true, transactionId, null);
+    }
+
+    public static DelegateResult failure(String error) {
+        return new DelegateResult(false, null, error);
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/EscrowDelegate.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/EscrowDelegate.java
@@ -1,0 +1,54 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.Destination;
+import io.ownera.ledger.adapter.service.model.ExecutionContext;
+import io.ownera.ledger.adapter.service.model.Source;
+
+import javax.annotation.Nullable;
+
+/**
+ * Optional delegate for external escrow operations. When wired, the escrow service calls
+ * hold/release/rollback on the delegate in addition to the local DB lock/unlock dance.
+ *
+ * <p>Ordering invariants the vanilla service enforces around delegate calls:
+ * <ul>
+ *   <li>{@code hold} — called <em>after</em> the local lock; if the delegate fails the local
+ *       lock is released.</li>
+ *   <li>{@code release} — called <em>before</em> the local unlockAndMove; if the delegate fails
+ *       the funds stay held.</li>
+ *   <li>{@code rollback} — called <em>before</em> the local unlock; if the delegate fails the
+ *       funds stay held.</li>
+ * </ul>
+ *
+ * <p>Mirrors Node's {@code EscrowDelegate} interface in
+ * {@code vanilla-service/src/interfaces.ts}.
+ */
+public interface EscrowDelegate {
+
+    DelegateResult hold(
+            String idempotencyKey,
+            Source source,
+            @Nullable Destination destination,
+            Asset asset,
+            String quantity,
+            String operationId,
+            @Nullable ExecutionContext exCtx);
+
+    DelegateResult release(
+            String idempotencyKey,
+            Source source,
+            Destination destination,
+            Asset asset,
+            String quantity,
+            String operationId,
+            @Nullable ExecutionContext exCtx);
+
+    DelegateResult rollback(
+            String idempotencyKey,
+            Source source,
+            Asset asset,
+            String quantity,
+            String operationId,
+            @Nullable ExecutionContext exCtx);
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/InboundTransferVerificationError.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/InboundTransferVerificationError.java
@@ -1,0 +1,17 @@
+package io.ownera.ledger.adapter.vanilla;
+
+/**
+ * Thrown by {@link TransferDelegate#onInboundTransfer} when the on-chain transfer cannot be
+ * verified. The vanilla service catches this and skips the local credit so the destination
+ * account does not get inflated by an unverifiable claim.
+ */
+public class InboundTransferVerificationError extends RuntimeException {
+
+    public InboundTransferVerificationError(String message) {
+        super(message);
+    }
+
+    public InboundTransferVerificationError(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerBalance.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerBalance.java
@@ -1,0 +1,23 @@
+package io.ownera.ledger.adapter.vanilla;
+
+/**
+ * Balance snapshot for one (finId, asset) pair. Strings, not BigDecimal, so the wire format
+ * round-trips cleanly with the {@code NUMERIC} column and downstream API models that hand
+ * balances around as strings.
+ */
+public final class LedgerBalance {
+
+    public final String balance;
+    public final String held;
+    public final String available;
+
+    public LedgerBalance(String balance, String held, String available) {
+        this.balance = balance;
+        this.held = held;
+        this.available = available;
+    }
+
+    public static LedgerBalance zero() {
+        return new LedgerBalance("0", "0", "0");
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerDetails.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerDetails.java
@@ -32,8 +32,22 @@ public final class LedgerDetails {
     @JsonProperty("execution_context")
     public final @Nullable LedgerExecutionContext executionContext;
 
+    /** External transaction id returned by a delegate (e.g. on-chain tx hash). The
+     *  service uses this both in the immediate response receipt and when later
+     *  reconstructing a receipt via {@code CommonService.getReceipt}. */
     @JsonProperty("transaction_id")
     public final @Nullable String transactionId;
+
+    /** External source counterparty (finId + non-FinId account info) preserved when the source
+     *  side is a wallet rather than a vanilla-tracked account. */
+    @JsonProperty("source_account")
+    public final @Nullable LedgerAccountRef sourceAccount;
+
+    /** External destination counterparty, same role as {@link #sourceAccount}. The vanilla
+     *  storage row for an external transfer only carries the local-side finId, so the
+     *  destination finId would be lost without this. */
+    @JsonProperty("destination_account")
+    public final @Nullable LedgerAccountRef destinationAccount;
 
     @JsonCreator
     public LedgerDetails(
@@ -41,16 +55,55 @@ public final class LedgerDetails {
             @JsonProperty("operation_id") @Nullable String operationId,
             @JsonProperty("operation_type") @Nullable String operationType,
             @JsonProperty("execution_context") @Nullable LedgerExecutionContext executionContext,
-            @JsonProperty("transaction_id") @Nullable String transactionId) {
+            @JsonProperty("transaction_id") @Nullable String transactionId,
+            @JsonProperty("source_account") @Nullable LedgerAccountRef sourceAccount,
+            @JsonProperty("destination_account") @Nullable LedgerAccountRef destinationAccount) {
         this.idempotencyKey = idempotencyKey;
         this.operationId = operationId;
         this.operationType = operationType;
         this.executionContext = executionContext;
         this.transactionId = transactionId;
+        this.sourceAccount = sourceAccount;
+        this.destinationAccount = destinationAccount;
+    }
+
+    /** Convenience constructor — five-arg form, no external account info. */
+    public LedgerDetails(String idempotencyKey, @Nullable String operationId,
+                         @Nullable String operationType, @Nullable LedgerExecutionContext executionContext,
+                         @Nullable String transactionId) {
+        this(idempotencyKey, operationId, operationType, executionContext, transactionId, null, null);
     }
 
     public LedgerDetails withIdempotencyKey(String newKey) {
-        return new LedgerDetails(newKey, operationId, operationType, executionContext, transactionId);
+        return new LedgerDetails(newKey, operationId, operationType, executionContext,
+                transactionId, sourceAccount, destinationAccount);
+    }
+
+    /** External counterparty descriptor preserved in JSONB so a stored row can rebuild the
+     *  Source/Destination pair on a later receipt lookup. {@code finId} is the counterparty's
+     *  fin id (the storage row's source/destination columns only hold the local side, so the
+     *  remote finId would otherwise be lost). {@code type + address} preserve a non-FinId
+     *  account shape (e.g. {@code LedgerAccount("wallet", "0xabc")}). */
+    public static final class LedgerAccountRef {
+
+        @JsonProperty("fin_id")
+        public final String finId;
+
+        @JsonProperty("type")
+        public final String type;
+
+        @JsonProperty("address")
+        public final String address;
+
+        @JsonCreator
+        public LedgerAccountRef(
+                @JsonProperty("fin_id") String finId,
+                @JsonProperty("type") String type,
+                @JsonProperty("address") String address) {
+            this.finId = finId;
+            this.type = type;
+            this.address = address;
+        }
     }
 
     public static final class LedgerExecutionContext {

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerDetails.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerDetails.java
@@ -1,0 +1,72 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import javax.annotation.Nullable;
+
+/**
+ * Per-transaction details serialized into {@code transactions.details JSONB}.
+ *
+ * <p>{@code idempotencyKey} is the required de-duplication key — the storage layer's CTE-based
+ * transfer checks for an existing row with the same {@code details->>'idempotency_key'} before
+ * mutating any account, and Postgres' unique index on that expression catches duplicates that
+ * slip past the CTE.
+ *
+ * <p>JSON property names use snake_case to match the Node vanilla service so adapters can mix
+ * stores from either implementation against the same database.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public final class LedgerDetails {
+
+    @JsonProperty("idempotency_key")
+    public final String idempotencyKey;
+
+    @JsonProperty("operation_id")
+    public final @Nullable String operationId;
+
+    @JsonProperty("operation_type")
+    public final @Nullable String operationType;
+
+    @JsonProperty("execution_context")
+    public final @Nullable LedgerExecutionContext executionContext;
+
+    @JsonProperty("transaction_id")
+    public final @Nullable String transactionId;
+
+    @JsonCreator
+    public LedgerDetails(
+            @JsonProperty("idempotency_key") String idempotencyKey,
+            @JsonProperty("operation_id") @Nullable String operationId,
+            @JsonProperty("operation_type") @Nullable String operationType,
+            @JsonProperty("execution_context") @Nullable LedgerExecutionContext executionContext,
+            @JsonProperty("transaction_id") @Nullable String transactionId) {
+        this.idempotencyKey = idempotencyKey;
+        this.operationId = operationId;
+        this.operationType = operationType;
+        this.executionContext = executionContext;
+        this.transactionId = transactionId;
+    }
+
+    public LedgerDetails withIdempotencyKey(String newKey) {
+        return new LedgerDetails(newKey, operationId, operationType, executionContext, transactionId);
+    }
+
+    public static final class LedgerExecutionContext {
+
+        @JsonProperty("planId")
+        public final String planId;
+
+        @JsonProperty("sequence")
+        public final int sequence;
+
+        @JsonCreator
+        public LedgerExecutionContext(
+                @JsonProperty("planId") String planId,
+                @JsonProperty("sequence") int sequence) {
+            this.planId = planId;
+            this.sequence = sequence;
+        }
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
@@ -166,6 +166,18 @@ public class LedgerStorage {
         return r != null ? toLedgerTransaction(r) : null;
     }
 
+    /**
+     * Returns the most-recent transaction tagged with the given {@code operation_id} in its
+     * details JSONB, or {@code null} when no row matches.
+     *
+     * <p>The same {@code operation_id} is intentionally written to multiple ledger rows over a
+     * single operation lifecycle — e.g. {@code hold} writes one row, then a later
+     * {@code release} / {@code rollback} / held {@code redeem} writes another with the same
+     * id. Callers asking for "the receipt for this operation" want the terminating event, so
+     * we sort by {@code created_at} descending and return the first hit. {@code id} is used as
+     * a tie-breaker so the result is fully deterministic even when two rows land in the same
+     * timestamp tick.
+     */
     @Nullable
     public LedgerTransaction findByOperationId(String operationId) {
         Record r = dsl.fetchOne(
@@ -173,7 +185,10 @@ public class LedgerStorage {
                         "amount::TEXT AS amount, source_held::TEXT AS source_held, " +
                         "destination_held::TEXT AS destination_held, " +
                         "action, details, created_at " +
-                        "FROM " + transactionsTable + " WHERE details->>'operation_id' = ?",
+                        "FROM " + transactionsTable + " " +
+                        "WHERE details->>'operation_id' = ? " +
+                        "ORDER BY created_at DESC, id DESC " +
+                        "LIMIT 1",
                 operationId);
         return r != null ? toLedgerTransaction(r) : null;
     }

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
@@ -39,6 +39,7 @@ public class LedgerStorage {
     private final String schema;
     private final String accountsTable;
     private final String transactionsTable;
+    private final String transferSql;
 
     public LedgerStorage(DSLContext dsl, String schemaName) {
         if (!SCHEMA_NAME_RE.matcher(schemaName).matches()) {
@@ -48,7 +49,84 @@ public class LedgerStorage {
         this.schema = schemaName;
         this.accountsTable = schemaName + ".accounts";
         this.transactionsTable = schemaName + ".transactions";
+        this.transferSql = String.format(TRANSFER_SQL_TEMPLATE, transactionsTable, accountsTable);
     }
+
+    /**
+     * One-shot CTE template: {@code %1$s} = transactions table, {@code %2$s} = accounts table.
+     * Splice once at construction (the schema name has already been validated against
+     * {@link #SCHEMA_NAME_RE}, so the substitution is safe). All runtime values come in
+     * through {@code ?} bind parameters.
+     */
+    private static final String TRANSFER_SQL_TEMPLATE =
+            "WITH params AS (\n" +
+                    "  SELECT CAST(? AS VARCHAR(50))  AS tx_id,\n" +
+                    "         CAST(? AS NUMERIC)      AS amount,\n" +
+                    "         CAST(? AS NUMERIC)      AS src_hold,\n" +
+                    "         CAST(? AS NUMERIC)      AS dst_hold,\n" +
+                    "         CAST(? AS VARCHAR(255)) AS source,\n" +
+                    "         CAST(? AS VARCHAR(255)) AS destination,\n" +
+                    "         CAST(? AS VARCHAR(255)) AS asset_id,\n" +
+                    "         CAST(? AS VARCHAR(64))  AS asset_type,\n" +
+                    "         CAST(? AS VARCHAR(64))  AS action,\n" +
+                    "         CAST(? AS JSONB)        AS details\n" +
+                    "),\n" +
+                    "lock_asset AS (\n" +
+                    "  SELECT pg_advisory_xact_lock(hashtext(p.asset_id), hashtext(p.asset_type))\n" +
+                    "  FROM params p\n" +
+                    "),\n" +
+                    "found_tx AS (\n" +
+                    "  SELECT t.id, t.asset_id, t.asset_type, t.source, t.destination,\n" +
+                    "         t.amount::TEXT AS amount, t.source_held::TEXT AS source_held,\n" +
+                    "         t.destination_held::TEXT AS destination_held,\n" +
+                    "         t.action, t.details, t.created_at\n" +
+                    "  FROM %1$s t, params p, lock_asset l\n" +
+                    "  WHERE t.details->>'idempotency_key' = p.details->>'idempotency_key'\n" +
+                    "),\n" +
+                    "src_upd AS (\n" +
+                    "  UPDATE %2$s a\n" +
+                    "  SET balance = a.balance - p.amount,\n" +
+                    "      held    = a.held + p.src_hold,\n" +
+                    "      updated_at = NOW()\n" +
+                    "  FROM params p\n" +
+                    "  WHERE a.fin_id = p.source\n" +
+                    "    AND a.asset_id = p.asset_id\n" +
+                    "    AND a.asset_type = p.asset_type\n" +
+                    "    AND NOT EXISTS (SELECT 1 FROM found_tx)\n" +
+                    "  RETURNING a.fin_id\n" +
+                    "),\n" +
+                    "dst_upd AS (\n" +
+                    "  UPDATE %2$s a\n" +
+                    "  SET balance = a.balance + p.amount,\n" +
+                    "      held    = a.held + p.dst_hold,\n" +
+                    "      updated_at = NOW()\n" +
+                    "  FROM params p\n" +
+                    "  WHERE a.fin_id = p.destination\n" +
+                    "    AND a.asset_id = p.asset_id\n" +
+                    "    AND a.asset_type = p.asset_type\n" +
+                    "    AND NOT EXISTS (SELECT 1 FROM found_tx)\n" +
+                    "  RETURNING a.fin_id\n" +
+                    "),\n" +
+                    "insert_tx AS (\n" +
+                    "  INSERT INTO %1$s\n" +
+                    "    (id, asset_id, asset_type, source, destination, amount, source_held, destination_held, action, details)\n" +
+                    "  SELECT p.tx_id, p.asset_id, p.asset_type,\n" +
+                    "         NULLIF(s.fin_id, ''), NULLIF(d.fin_id, ''),\n" +
+                    "         p.amount, p.src_hold, p.dst_hold, p.action, p.details\n" +
+                    "  FROM params p\n" +
+                    "    LEFT OUTER JOIN src_upd s ON 1=1\n" +
+                    "    LEFT OUTER JOIN dst_upd d ON 1=1\n" +
+                    "  WHERE NOT EXISTS (SELECT 1 FROM found_tx)\n" +
+                    "    AND COALESCE(s.fin_id, '') = p.source\n" +
+                    "    AND COALESCE(d.fin_id, '') = p.destination\n" +
+                    "  RETURNING id, asset_id, asset_type, source, destination,\n" +
+                    "            amount::TEXT AS amount, source_held::TEXT AS source_held,\n" +
+                    "            destination_held::TEXT AS destination_held,\n" +
+                    "            action, details, created_at\n" +
+                    ")\n" +
+                    "SELECT * FROM insert_tx\n" +
+                    "UNION ALL\n" +
+                    "SELECT * FROM found_tx";
 
     /** Schema this storage is bound to; callers (e.g. AccountMappingService) can use it to
      *  qualify other queries against the same database. */
@@ -219,79 +297,11 @@ public class LedgerStorage {
             LedgerDetails details) {
         String txId = generateTxId();
         String detailsJson = serializeDetails(details);
-        String sql =
-                "WITH params AS (" +
-                        "  SELECT CAST(? AS VARCHAR(50))  AS tx_id," +
-                        "         CAST(? AS NUMERIC)      AS amount," +
-                        "         CAST(? AS NUMERIC)      AS src_hold," +
-                        "         CAST(? AS NUMERIC)      AS dst_hold," +
-                        "         CAST(? AS VARCHAR(255)) AS source," +
-                        "         CAST(? AS VARCHAR(255)) AS destination," +
-                        "         CAST(? AS VARCHAR(255)) AS asset_id," +
-                        "         CAST(? AS VARCHAR(64))  AS asset_type," +
-                        "         CAST(? AS VARCHAR(64))  AS action," +
-                        "         CAST(? AS JSONB)        AS details" +
-                        ")," +
-                        "lock_asset AS (" +
-                        "  SELECT pg_advisory_xact_lock(hashtext(p.asset_id), hashtext(p.asset_type))" +
-                        "  FROM params p" +
-                        ")," +
-                        "found_tx AS (" +
-                        "  SELECT t.id, t.asset_id, t.asset_type, t.source, t.destination," +
-                        "         t.amount::TEXT AS amount, t.source_held::TEXT AS source_held," +
-                        "         t.destination_held::TEXT AS destination_held," +
-                        "         t.action, t.details, t.created_at" +
-                        "  FROM " + transactionsTable + " t, params p, lock_asset l" +
-                        "  WHERE t.details->>'idempotency_key' = p.details->>'idempotency_key'" +
-                        ")," +
-                        "src_upd AS (" +
-                        "  UPDATE " + accountsTable + " a" +
-                        "  SET balance = a.balance - p.amount," +
-                        "      held    = a.held + p.src_hold," +
-                        "      updated_at = NOW()" +
-                        "  FROM params p" +
-                        "  WHERE a.fin_id = p.source" +
-                        "    AND a.asset_id = p.asset_id" +
-                        "    AND a.asset_type = p.asset_type" +
-                        "    AND NOT EXISTS (SELECT 1 FROM found_tx)" +
-                        "  RETURNING a.fin_id" +
-                        ")," +
-                        "dst_upd AS (" +
-                        "  UPDATE " + accountsTable + " a" +
-                        "  SET balance = a.balance + p.amount," +
-                        "      held    = a.held + p.dst_hold," +
-                        "      updated_at = NOW()" +
-                        "  FROM params p" +
-                        "  WHERE a.fin_id = p.destination" +
-                        "    AND a.asset_id = p.asset_id" +
-                        "    AND a.asset_type = p.asset_type" +
-                        "    AND NOT EXISTS (SELECT 1 FROM found_tx)" +
-                        "  RETURNING a.fin_id" +
-                        ")," +
-                        "insert_tx AS (" +
-                        "  INSERT INTO " + transactionsTable +
-                        "    (id, asset_id, asset_type, source, destination, amount, source_held, destination_held, action, details)" +
-                        "  SELECT p.tx_id, p.asset_id, p.asset_type," +
-                        "         NULLIF(s.fin_id, ''), NULLIF(d.fin_id, '')," +
-                        "         p.amount, p.src_hold, p.dst_hold, p.action, p.details" +
-                        "  FROM params p" +
-                        "    LEFT OUTER JOIN src_upd s ON 1=1" +
-                        "    LEFT OUTER JOIN dst_upd d ON 1=1" +
-                        "  WHERE NOT EXISTS (SELECT 1 FROM found_tx)" +
-                        "    AND COALESCE(s.fin_id, '') = p.source" +
-                        "    AND COALESCE(d.fin_id, '') = p.destination" +
-                        "  RETURNING id, asset_id, asset_type, source, destination," +
-                        "            amount::TEXT AS amount, source_held::TEXT AS source_held," +
-                        "            destination_held::TEXT AS destination_held," +
-                        "            action, details, created_at" +
-                        ")" +
-                        "SELECT * FROM insert_tx" +
-                        " UNION ALL " +
-                        "SELECT * FROM found_tx";
         try {
             // detailsJson is passed as a String; the CAST(? AS JSONB) in the SQL turns it into
-            // the JSONB the table expects.
-            Result<Record> rows = dsl.fetch(sql,
+            // the JSONB the table expects. transferSql is precomputed once per instance with
+            // the schema-qualified table names already spliced in (see TRANSFER_SQL_TEMPLATE).
+            Result<Record> rows = dsl.fetch(transferSql,
                     txId, amount, sourceHeld, destHeld,
                     source, destination, assetId, assetType,
                     action, detailsJson);

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
@@ -1,0 +1,358 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.ownera.ledger.adapter.service.BusinessException;
+import org.jooq.DSLContext;
+import org.jooq.JSONB;
+import org.jooq.Record;
+import org.jooq.Result;
+
+import javax.annotation.Nullable;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.Optional;
+import java.util.regex.Pattern;
+
+/**
+ * PostgreSQL-backed ledger storage for the vanilla service. Provides atomic balance operations
+ * with idempotency via CTE-based queries, ported from the Node vanilla adapter
+ * ({@code vanilla-service/src/storage.ts}).
+ *
+ * <p>The schema name qualifying {@code accounts} and {@code transactions} is configurable so
+ * multiple adapters can share a database without colliding. It is validated against a strict
+ * identifier regex to keep it safe to splice into raw SQL.
+ *
+ * <p>Concurrency: each mutating call takes a per-asset {@code pg_advisory_xact_lock} keyed on
+ * {@code (asset_id, asset_type)}. Two operations on the same asset serialize; operations on
+ * different assets run in parallel.
+ */
+public class LedgerStorage {
+
+    private static final String DEFAULT_ASSET_TYPE = "finp2p";
+    private static final Pattern SCHEMA_NAME_RE = Pattern.compile("^[a-zA-Z_][a-zA-Z0-9_]*$");
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+    private static final SecureRandom RNG = new SecureRandom();
+
+    private final DSLContext dsl;
+    private final String schema;
+    private final String accountsTable;
+    private final String transactionsTable;
+
+    public LedgerStorage(DSLContext dsl, String schemaName) {
+        if (!SCHEMA_NAME_RE.matcher(schemaName).matches()) {
+            throw new IllegalArgumentException("Invalid schema name: " + schemaName);
+        }
+        this.dsl = dsl;
+        this.schema = schemaName;
+        this.accountsTable = schemaName + ".accounts";
+        this.transactionsTable = schemaName + ".transactions";
+    }
+
+    /** Schema this storage is bound to; callers (e.g. AccountMappingService) can use it to
+     *  qualify other queries against the same database. */
+    public String schemaName() {
+        return schema;
+    }
+
+    public void ensureAccount(String finId, String assetId) {
+        ensureAccount(finId, assetId, DEFAULT_ASSET_TYPE);
+    }
+
+    public void ensureAccount(String finId, String assetId, String assetType) {
+        dsl.execute(
+                "INSERT INTO " + accountsTable + " (fin_id, asset_id, asset_type) " +
+                        "VALUES (?, ?, ?) " +
+                        "ON CONFLICT (fin_id, asset_id, asset_type) DO NOTHING",
+                finId, assetId, assetType);
+    }
+
+    // ─── Balance ────────────────────────────────────────────────────────────
+
+    public LedgerBalance getBalance(String finId, String assetId) {
+        return getBalance(finId, assetId, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerBalance getBalance(String finId, String assetId, String assetType) {
+        Record r = dsl.fetchOne(
+                "SELECT balance::TEXT AS balance, held::TEXT AS held, " +
+                        "(balance - held)::TEXT AS available " +
+                        "FROM " + accountsTable + " " +
+                        "WHERE fin_id = ? AND asset_id = ? AND asset_type = ?",
+                finId, assetId, assetType);
+        if (r == null) return LedgerBalance.zero();
+        return new LedgerBalance(
+                r.get("balance", String.class),
+                r.get("held", String.class),
+                r.get("available", String.class));
+    }
+
+    // ─── Account-level sugar over transfer() ────────────────────────────────
+
+    public LedgerTransaction credit(String finId, String amount, String assetId, LedgerDetails details) {
+        return credit(finId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction credit(String finId, String amount, String assetId, LedgerDetails details, String assetType) {
+        return transfer("", finId, amount, "0", "0", assetId, assetType, "credit", details);
+    }
+
+    public LedgerTransaction debit(String finId, String amount, String assetId, LedgerDetails details) {
+        return debit(finId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction debit(String finId, String amount, String assetId, LedgerDetails details, String assetType) {
+        return transfer(finId, "", amount, "0", "0", assetId, assetType, "debit", details);
+    }
+
+    public LedgerTransaction lock(String finId, String amount, String assetId, LedgerDetails details) {
+        return lock(finId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction lock(String finId, String amount, String assetId, LedgerDetails details, String assetType) {
+        return transfer(finId, "", "0", amount, "0", assetId, assetType, "lock", details);
+    }
+
+    public LedgerTransaction unlock(String finId, String amount, String assetId, LedgerDetails details) {
+        return unlock(finId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction unlock(String finId, String amount, String assetId, LedgerDetails details, String assetType) {
+        return transfer(finId, "", "0", "-" + amount, "0", assetId, assetType, "unlock", details);
+    }
+
+    public LedgerTransaction move(String srcFinId, String dstFinId, String amount, String assetId, LedgerDetails details) {
+        return move(srcFinId, dstFinId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction move(String srcFinId, String dstFinId, String amount, String assetId, LedgerDetails details, String assetType) {
+        if (srcFinId.equals(dstFinId)) {
+            throw new BusinessException(1, "Cannot move from account to itself: " + srcFinId);
+        }
+        return transfer(srcFinId, dstFinId, amount, "0", "0", assetId, assetType, "move", details);
+    }
+
+    public LedgerTransaction unlockAndMove(String srcFinId, String dstFinId, String amount, String assetId, LedgerDetails details) {
+        return unlockAndMove(srcFinId, dstFinId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction unlockAndMove(String srcFinId, String dstFinId, String amount, String assetId, LedgerDetails details, String assetType) {
+        if (srcFinId.equals(dstFinId)) {
+            throw new BusinessException(1, "Cannot move from account to itself: " + srcFinId);
+        }
+        return transfer(srcFinId, dstFinId, amount, "-" + amount, "0", assetId, assetType, "unlock-and-move", details);
+    }
+
+    public LedgerTransaction unlockAndDebit(String finId, String amount, String assetId, LedgerDetails details) {
+        return unlockAndDebit(finId, amount, assetId, details, DEFAULT_ASSET_TYPE);
+    }
+
+    public LedgerTransaction unlockAndDebit(String finId, String amount, String assetId, LedgerDetails details, String assetType) {
+        return transfer(finId, "", amount, "-" + amount, "0", assetId, assetType, "unlock-and-debit", details);
+    }
+
+    // ─── Lookups ────────────────────────────────────────────────────────────
+
+    @Nullable
+    public LedgerTransaction getTransaction(String txId) {
+        Record r = dsl.fetchOne(
+                "SELECT id, asset_id, asset_type, source, destination, " +
+                        "amount::TEXT AS amount, source_held::TEXT AS source_held, " +
+                        "destination_held::TEXT AS destination_held, " +
+                        "action, details, created_at " +
+                        "FROM " + transactionsTable + " WHERE id = ?",
+                txId);
+        return r != null ? toLedgerTransaction(r) : null;
+    }
+
+    @Nullable
+    public LedgerTransaction findByOperationId(String operationId) {
+        Record r = dsl.fetchOne(
+                "SELECT id, asset_id, asset_type, source, destination, " +
+                        "amount::TEXT AS amount, source_held::TEXT AS source_held, " +
+                        "destination_held::TEXT AS destination_held, " +
+                        "action, details, created_at " +
+                        "FROM " + transactionsTable + " WHERE details->>'operation_id' = ?",
+                operationId);
+        return r != null ? toLedgerTransaction(r) : null;
+    }
+
+    // ─── Atomic CTE transfer ────────────────────────────────────────────────
+
+    /**
+     * The one-shot CTE that atomically:
+     * <ol>
+     *   <li>Takes a per-asset advisory lock so concurrent operations on the same asset serialize.</li>
+     *   <li>Looks for an existing transaction with the same idempotency_key; if found, returns it.</li>
+     *   <li>Otherwise updates source/destination accounts and inserts the new transaction row.</li>
+     * </ol>
+     *
+     * <p>The {@code CHECK (balance &gt;= 0)} and {@code CHECK (held &lt;= balance)} constraints on
+     * {@code accounts} are the safety net: any update that would violate them aborts the whole
+     * CTE, which is translated to a {@link BusinessException} here.
+     */
+    private LedgerTransaction transfer(
+            String source,
+            String destination,
+            String amount,
+            String sourceHeld,
+            String destHeld,
+            String assetId,
+            String assetType,
+            String action,
+            LedgerDetails details) {
+        String txId = generateTxId();
+        String detailsJson = serializeDetails(details);
+        String sql =
+                "WITH params AS (" +
+                        "  SELECT CAST(? AS VARCHAR(50))  AS tx_id," +
+                        "         CAST(? AS NUMERIC)      AS amount," +
+                        "         CAST(? AS NUMERIC)      AS src_hold," +
+                        "         CAST(? AS NUMERIC)      AS dst_hold," +
+                        "         CAST(? AS VARCHAR(255)) AS source," +
+                        "         CAST(? AS VARCHAR(255)) AS destination," +
+                        "         CAST(? AS VARCHAR(255)) AS asset_id," +
+                        "         CAST(? AS VARCHAR(64))  AS asset_type," +
+                        "         CAST(? AS VARCHAR(64))  AS action," +
+                        "         CAST(? AS JSONB)        AS details" +
+                        ")," +
+                        "lock_asset AS (" +
+                        "  SELECT pg_advisory_xact_lock(hashtext(p.asset_id), hashtext(p.asset_type))" +
+                        "  FROM params p" +
+                        ")," +
+                        "found_tx AS (" +
+                        "  SELECT t.id, t.asset_id, t.asset_type, t.source, t.destination," +
+                        "         t.amount::TEXT AS amount, t.source_held::TEXT AS source_held," +
+                        "         t.destination_held::TEXT AS destination_held," +
+                        "         t.action, t.details, t.created_at" +
+                        "  FROM " + transactionsTable + " t, params p, lock_asset l" +
+                        "  WHERE t.details->>'idempotency_key' = p.details->>'idempotency_key'" +
+                        ")," +
+                        "src_upd AS (" +
+                        "  UPDATE " + accountsTable + " a" +
+                        "  SET balance = a.balance - p.amount," +
+                        "      held    = a.held + p.src_hold," +
+                        "      updated_at = NOW()" +
+                        "  FROM params p" +
+                        "  WHERE a.fin_id = p.source" +
+                        "    AND a.asset_id = p.asset_id" +
+                        "    AND a.asset_type = p.asset_type" +
+                        "    AND NOT EXISTS (SELECT 1 FROM found_tx)" +
+                        "  RETURNING a.fin_id" +
+                        ")," +
+                        "dst_upd AS (" +
+                        "  UPDATE " + accountsTable + " a" +
+                        "  SET balance = a.balance + p.amount," +
+                        "      held    = a.held + p.dst_hold," +
+                        "      updated_at = NOW()" +
+                        "  FROM params p" +
+                        "  WHERE a.fin_id = p.destination" +
+                        "    AND a.asset_id = p.asset_id" +
+                        "    AND a.asset_type = p.asset_type" +
+                        "    AND NOT EXISTS (SELECT 1 FROM found_tx)" +
+                        "  RETURNING a.fin_id" +
+                        ")," +
+                        "insert_tx AS (" +
+                        "  INSERT INTO " + transactionsTable +
+                        "    (id, asset_id, asset_type, source, destination, amount, source_held, destination_held, action, details)" +
+                        "  SELECT p.tx_id, p.asset_id, p.asset_type," +
+                        "         NULLIF(s.fin_id, ''), NULLIF(d.fin_id, '')," +
+                        "         p.amount, p.src_hold, p.dst_hold, p.action, p.details" +
+                        "  FROM params p" +
+                        "    LEFT OUTER JOIN src_upd s ON 1=1" +
+                        "    LEFT OUTER JOIN dst_upd d ON 1=1" +
+                        "  WHERE NOT EXISTS (SELECT 1 FROM found_tx)" +
+                        "    AND COALESCE(s.fin_id, '') = p.source" +
+                        "    AND COALESCE(d.fin_id, '') = p.destination" +
+                        "  RETURNING id, asset_id, asset_type, source, destination," +
+                        "            amount::TEXT AS amount, source_held::TEXT AS source_held," +
+                        "            destination_held::TEXT AS destination_held," +
+                        "            action, details, created_at" +
+                        ")" +
+                        "SELECT * FROM insert_tx" +
+                        " UNION ALL " +
+                        "SELECT * FROM found_tx";
+        try {
+            // detailsJson is passed as a String; the CAST(? AS JSONB) in the SQL turns it into
+            // the JSONB the table expects.
+            Result<Record> rows = dsl.fetch(sql,
+                    txId, amount, sourceHeld, destHeld,
+                    source, destination, assetId, assetType,
+                    action, detailsJson);
+            if (rows.isEmpty()) {
+                throw new BusinessException(1,
+                        "Transfer failed: account not found for " + Optional.of(source).filter(s -> !s.isEmpty()).orElse(destination));
+            }
+            return toLedgerTransaction(rows.get(0));
+        } catch (BusinessException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            String msg = String.valueOf(e.getMessage());
+            // accounts_balance_check and accounts_check are the two CHECK constraints in the
+            // accounts table; a violation here means the operation would push balance < 0 or
+            // held > balance.
+            if (msg.contains("accounts_balance_check") || msg.contains("accounts_check")) {
+                throw new BusinessException(1,
+                        "Insufficient balance for " + action + " on account "
+                                + Optional.of(source).filter(s -> !s.isEmpty()).orElse(destination));
+            }
+            throw e;
+        }
+    }
+
+    private static LedgerTransaction toLedgerTransaction(Record r) {
+        Object detailsRaw = r.get("details");
+        LedgerDetails details = parseDetails(detailsRaw);
+        Object createdAtRaw = r.get("created_at");
+        Instant createdAt;
+        if (createdAtRaw instanceof java.sql.Timestamp) {
+            createdAt = ((java.sql.Timestamp) createdAtRaw).toInstant();
+        } else if (createdAtRaw instanceof java.time.OffsetDateTime) {
+            createdAt = ((java.time.OffsetDateTime) createdAtRaw).toInstant();
+        } else if (createdAtRaw instanceof Instant) {
+            createdAt = (Instant) createdAtRaw;
+        } else {
+            createdAt = Instant.now();
+        }
+        return new LedgerTransaction(
+                r.get("id", String.class),
+                r.get("asset_id", String.class),
+                r.get("asset_type", String.class),
+                r.get("source", String.class),
+                r.get("destination", String.class),
+                r.get("amount", String.class),
+                r.get("source_held", String.class),
+                r.get("destination_held", String.class),
+                r.get("action", String.class),
+                details,
+                createdAt);
+    }
+
+    private static LedgerDetails parseDetails(@Nullable Object raw) {
+        if (raw == null) {
+            return new LedgerDetails("", null, null, null, null);
+        }
+        String json = raw instanceof JSONB ? ((JSONB) raw).data() : raw.toString();
+        try {
+            return MAPPER.readValue(json, LedgerDetails.class);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to parse transaction details JSON: " + json, e);
+        }
+    }
+
+    private static String serializeDetails(LedgerDetails details) {
+        try {
+            return MAPPER.writeValueAsString(details);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to serialize transaction details", e);
+        }
+    }
+
+    /** Random 32-byte base64url id, matching Node's bs58 length. */
+    private static String generateTxId() {
+        byte[] bytes = new byte[32];
+        RNG.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
@@ -37,8 +37,10 @@ public class LedgerStorage {
 
     private final DSLContext dsl;
     private final String schema;
-    private final String accountsTable;
-    private final String transactionsTable;
+    private final String ensureAccountSql;
+    private final String getBalanceSql;
+    private final String getTransactionSql;
+    private final String findByOperationIdSql;
     private final String transferSql;
 
     public LedgerStorage(DSLContext dsl, String schemaName) {
@@ -47,10 +49,46 @@ public class LedgerStorage {
         }
         this.dsl = dsl;
         this.schema = schemaName;
-        this.accountsTable = schemaName + ".accounts";
-        this.transactionsTable = schemaName + ".transactions";
-        this.transferSql = String.format(TRANSFER_SQL_TEMPLATE, transactionsTable, accountsTable);
+        String accountsTable = schemaName + ".accounts";
+        String transactionsTable = schemaName + ".transactions";
+        this.ensureAccountSql     = String.format(ENSURE_ACCOUNT_TEMPLATE,      accountsTable);
+        this.getBalanceSql        = String.format(GET_BALANCE_TEMPLATE,         accountsTable);
+        this.getTransactionSql    = String.format(GET_TRANSACTION_TEMPLATE,     transactionsTable);
+        this.findByOperationIdSql = String.format(FIND_BY_OPERATION_ID_TEMPLATE, transactionsTable);
+        this.transferSql          = String.format(TRANSFER_SQL_TEMPLATE,        transactionsTable, accountsTable);
     }
+
+    // SQL templates. Table names are spliced once at construction via String.format — they're
+    // validated against {@link #SCHEMA_NAME_RE} before any substitution, so splicing is safe.
+    // All runtime values flow through {@code ?} bind parameters.
+
+    private static final String ENSURE_ACCOUNT_TEMPLATE =
+            "INSERT INTO %s (fin_id, asset_id, asset_type) " +
+                    "VALUES (?, ?, ?) " +
+                    "ON CONFLICT (fin_id, asset_id, asset_type) DO NOTHING";
+
+    private static final String GET_BALANCE_TEMPLATE =
+            "SELECT balance::TEXT AS balance, held::TEXT AS held, " +
+                    "       (balance - held)::TEXT AS available " +
+                    "FROM %s " +
+                    "WHERE fin_id = ? AND asset_id = ? AND asset_type = ?";
+
+    private static final String GET_TRANSACTION_TEMPLATE =
+            "SELECT id, asset_id, asset_type, source, destination, " +
+                    "       amount::TEXT AS amount, source_held::TEXT AS source_held, " +
+                    "       destination_held::TEXT AS destination_held, " +
+                    "       action, details, created_at " +
+                    "FROM %s WHERE id = ?";
+
+    private static final String FIND_BY_OPERATION_ID_TEMPLATE =
+            "SELECT id, asset_id, asset_type, source, destination, " +
+                    "       amount::TEXT AS amount, source_held::TEXT AS source_held, " +
+                    "       destination_held::TEXT AS destination_held, " +
+                    "       action, details, created_at " +
+                    "FROM %s " +
+                    "WHERE details->>'operation_id' = ? " +
+                    "ORDER BY created_at DESC, id DESC " +
+                    "LIMIT 1";
 
     /**
      * One-shot CTE template: {@code %1$s} = transactions table, {@code %2$s} = accounts table.
@@ -139,11 +177,7 @@ public class LedgerStorage {
     }
 
     public void ensureAccount(String finId, String assetId, String assetType) {
-        dsl.execute(
-                "INSERT INTO " + accountsTable + " (fin_id, asset_id, asset_type) " +
-                        "VALUES (?, ?, ?) " +
-                        "ON CONFLICT (fin_id, asset_id, asset_type) DO NOTHING",
-                finId, assetId, assetType);
+        dsl.execute(ensureAccountSql, finId, assetId, assetType);
     }
 
     // ─── Balance ────────────────────────────────────────────────────────────
@@ -153,12 +187,7 @@ public class LedgerStorage {
     }
 
     public LedgerBalance getBalance(String finId, String assetId, String assetType) {
-        Record r = dsl.fetchOne(
-                "SELECT balance::TEXT AS balance, held::TEXT AS held, " +
-                        "(balance - held)::TEXT AS available " +
-                        "FROM " + accountsTable + " " +
-                        "WHERE fin_id = ? AND asset_id = ? AND asset_type = ?",
-                finId, assetId, assetType);
+        Record r = dsl.fetchOne(getBalanceSql, finId, assetId, assetType);
         if (r == null) return LedgerBalance.zero();
         return new LedgerBalance(
                 r.get("balance", String.class),
@@ -234,13 +263,7 @@ public class LedgerStorage {
 
     @Nullable
     public LedgerTransaction getTransaction(String txId) {
-        Record r = dsl.fetchOne(
-                "SELECT id, asset_id, asset_type, source, destination, " +
-                        "amount::TEXT AS amount, source_held::TEXT AS source_held, " +
-                        "destination_held::TEXT AS destination_held, " +
-                        "action, details, created_at " +
-                        "FROM " + transactionsTable + " WHERE id = ?",
-                txId);
+        Record r = dsl.fetchOne(getTransactionSql, txId);
         return r != null ? toLedgerTransaction(r) : null;
     }
 
@@ -258,16 +281,7 @@ public class LedgerStorage {
      */
     @Nullable
     public LedgerTransaction findByOperationId(String operationId) {
-        Record r = dsl.fetchOne(
-                "SELECT id, asset_id, asset_type, source, destination, " +
-                        "amount::TEXT AS amount, source_held::TEXT AS source_held, " +
-                        "destination_held::TEXT AS destination_held, " +
-                        "action, details, created_at " +
-                        "FROM " + transactionsTable + " " +
-                        "WHERE details->>'operation_id' = ? " +
-                        "ORDER BY created_at DESC, id DESC " +
-                        "LIMIT 1",
-                operationId);
+        Record r = dsl.fetchOne(findByOperationIdSql, operationId);
         return r != null ? toLedgerTransaction(r) : null;
     }
 

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerTransaction.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerTransaction.java
@@ -1,0 +1,42 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import javax.annotation.Nullable;
+import java.time.Instant;
+
+/**
+ * One row of the {@code transactions} table.
+ *
+ * <p>Strings for the numeric columns so they round-trip cleanly through the API layer
+ * (which deals in string-encoded NUMERICs) without an intermediate {@code BigDecimal}.
+ */
+public final class LedgerTransaction {
+
+    public final String id;
+    public final String assetId;
+    public final String assetType;
+    public final @Nullable String source;
+    public final @Nullable String destination;
+    public final String amount;
+    public final String sourceHeld;
+    public final String destinationHeld;
+    public final String action;
+    public final LedgerDetails details;
+    public final Instant createdAt;
+
+    public LedgerTransaction(String id, String assetId, String assetType,
+                             @Nullable String source, @Nullable String destination,
+                             String amount, String sourceHeld, String destinationHeld,
+                             String action, LedgerDetails details, Instant createdAt) {
+        this.id = id;
+        this.assetId = assetId;
+        this.assetType = assetType;
+        this.source = source;
+        this.destination = destination;
+        this.amount = amount;
+        this.sourceHeld = sourceHeld;
+        this.destinationHeld = destinationHeld;
+        this.action = action;
+        this.details = details;
+        this.createdAt = createdAt;
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/TransferDelegate.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/TransferDelegate.java
@@ -1,0 +1,50 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.Destination;
+import io.ownera.ledger.adapter.service.model.ExecutionContext;
+import io.ownera.ledger.adapter.service.model.Source;
+
+import javax.annotation.Nullable;
+
+/**
+ * Delegate for external transfer operations (on-chain transfers, IBAN payouts).
+ *
+ * <p>The vanilla service wraps each call with local DB safeguards:
+ * <ol>
+ *   <li>Lock funds in the local ledger.</li>
+ *   <li>Call {@link #outboundTransfer}.</li>
+ *   <li>On success → unlock and debit locally.</li>
+ *   <li>On failure → unlock locally (funds return to available).</li>
+ * </ol>
+ *
+ * <p>Mirrors Node's {@code TransferDelegate} interface in
+ * {@code vanilla-service/src/interfaces.ts}.
+ */
+public interface TransferDelegate {
+
+    DelegateResult outboundTransfer(
+            String idempotencyKey,
+            Source source,
+            Destination destination,
+            Asset asset,
+            String quantity,
+            @Nullable ExecutionContext exCtx);
+
+    /**
+     * Called before crediting a destination account for an inbound transfer. Implementations
+     * should verify that the on-chain transfer actually happened; throw
+     * {@link InboundTransferVerificationError} to abort the local credit.
+     *
+     * <p>Default no-op: adapters that trust their inbound sources can leave this unimplemented.
+     */
+    default void onInboundTransfer(
+            String transactionId,
+            Source source,
+            Asset asset,
+            Destination destination,
+            String amount,
+            @Nullable ExecutionContext exCtx) {
+        // no-op
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
@@ -1,0 +1,424 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.CommonService;
+import io.ownera.ledger.adapter.service.EscrowService;
+import io.ownera.ledger.adapter.service.HealthService;
+import io.ownera.ledger.adapter.service.TokenService;
+import io.ownera.ledger.adapter.service.mapping.AccountMapping;
+import io.ownera.ledger.adapter.service.mapping.AccountMappingService;
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.AssetBind;
+import io.ownera.ledger.adapter.service.model.AssetCreationResult;
+import io.ownera.ledger.adapter.service.model.AssetCreationStatus;
+import io.ownera.ledger.adapter.service.model.AssetDenomination;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import io.ownera.ledger.adapter.service.model.Balance;
+import io.ownera.ledger.adapter.service.model.Destination;
+import io.ownera.ledger.adapter.service.model.ErrorDetails;
+import io.ownera.ledger.adapter.service.model.ExecutionContext;
+import io.ownera.ledger.adapter.service.model.FailedReceiptStatus;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+import io.ownera.ledger.adapter.service.model.LedgerAssetIdentifier;
+import io.ownera.ledger.adapter.service.model.LedgerReference;
+import io.ownera.ledger.adapter.service.model.OperationStatus;
+import io.ownera.ledger.adapter.service.model.OperationType;
+import io.ownera.ledger.adapter.service.model.ProofPolicy;
+import io.ownera.ledger.adapter.service.model.Receipt;
+import io.ownera.ledger.adapter.service.model.ReceiptOperation;
+import io.ownera.ledger.adapter.service.model.Signature;
+import io.ownera.ledger.adapter.service.model.Source;
+import io.ownera.ledger.adapter.service.model.SuccessReceiptStatus;
+import io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation;
+import io.ownera.ledger.adapter.service.model.TradeDetails;
+import io.ownera.ledger.adapter.service.model.TransactionDetails;
+import io.ownera.ledger.adapter.service.plan.InboundTransferHook;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.annotation.Nullable;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Reference per-investor ledger implementation, ported from
+ * {@code vanilla-service/src/service.ts} in the Node skeleton.
+ *
+ * <p>Implements the core service interfaces against a {@link LedgerStorage}-backed account
+ * model. Adapters that want to extend with on-chain integrations register one or more of
+ * {@link AssetDelegate}, {@link TransferDelegate}, {@link EscrowDelegate}; the local DB
+ * lock/unlock dance still runs around each delegate call so failures roll back cleanly.
+ *
+ * <p>{@link AccountMappingService} is delegated to the skeleton's existing implementation
+ * (passed in via the constructor) so vanilla doesn't fork a parallel mapping store.
+ *
+ * <p>PaymentService is intentionally not implemented here; the Node vanilla does the same.
+ * Adapters compose vanilla with their own payment service when needed.
+ */
+public class VanillaServiceImpl implements
+        TokenService, EscrowService, CommonService, HealthService,
+        AccountMappingService, InboundTransferHook {
+
+    private static final Logger logger = LoggerFactory.getLogger(VanillaServiceImpl.class);
+    private static final SecureRandom RNG = new SecureRandom();
+
+    private final LedgerStorage storage;
+    private final AccountMappingService accountMappingService;
+    private final @Nullable AssetDelegate assetDelegate;
+    private final @Nullable TransferDelegate transferDelegate;
+    private final @Nullable EscrowDelegate escrowDelegate;
+
+    public VanillaServiceImpl(LedgerStorage storage,
+                              AccountMappingService accountMappingService) {
+        this(storage, accountMappingService, null, null, null);
+    }
+
+    public VanillaServiceImpl(LedgerStorage storage,
+                              AccountMappingService accountMappingService,
+                              @Nullable AssetDelegate assetDelegate,
+                              @Nullable TransferDelegate transferDelegate,
+                              @Nullable EscrowDelegate escrowDelegate) {
+        this.storage = storage;
+        this.accountMappingService = accountMappingService;
+        this.assetDelegate = assetDelegate;
+        this.transferDelegate = transferDelegate;
+        this.escrowDelegate = escrowDelegate;
+    }
+
+    // ─── TokenService ───────────────────────────────────────────────────────
+
+    @Override
+    public AssetCreationStatus createAsset(String idempotencyKey, Asset asset,
+                                           @Nullable AssetBind assetBind, @Nullable Object assetMetadata,
+                                           @Nullable String assetName, @Nullable String issuerId,
+                                           @Nullable AssetDenomination assetDenomination) {
+        logger.info("Creating asset {}", asset.assetId);
+        if (assetDelegate != null) {
+            AssetCreationResult result = assetDelegate.createAsset(
+                    idempotencyKey, asset.assetId, assetBind, assetMetadata,
+                    assetName, issuerId, assetDenomination);
+            return new SuccessfulAssetCreation(result);
+        }
+        // No delegate → emit a synthetic CAIP-19 identifier so router-side flows still work
+        // for local-only deployments. Matches Node's `db / vanilla` standard for the fallback.
+        String tokenId;
+        String network;
+        String tokenStandard;
+        if (assetBind != null && assetBind.tokenIdentifier != null) {
+            tokenId = assetBind.tokenIdentifier.tokenId;
+            network = "db";
+            tokenStandard = "vanilla";
+        } else {
+            tokenId = generateCid();
+            network = "db";
+            tokenStandard = "vanilla";
+        }
+        AssetCreationResult result = new AssetCreationResult(
+                tokenId, new LedgerReference(network, "", tokenStandard, null));
+        return new SuccessfulAssetCreation(result);
+    }
+
+    @Override
+    public ReceiptOperation issue(String idempotencyKey, Asset asset, FinIdAccount to,
+                                  String amount, @Nullable ExecutionContext exCtx) {
+        logger.info("Issuing {} of {} to {}", amount, asset.assetId, to.finId);
+        storage.ensureAccount(to.finId, asset.assetId, asset.assetType.name().toLowerCase());
+        LedgerTransaction tx = storage.credit(to.finId, amount, asset.assetId,
+                details(idempotencyKey, null, "issue", exCtx), asset.assetType.name().toLowerCase());
+        Receipt receipt = buildReceipt(tx, OperationType.ISSUE, asset, null,
+                new Destination(to.finId, new FinIdAccount(to.finId)), amount, exCtx, null, null);
+        return new SuccessReceiptStatus(receipt);
+    }
+
+    @Override
+    public ReceiptOperation transfer(String idempotencyKey, String nonce, Source source,
+                                     Destination destination, Asset asset, String quantity,
+                                     Signature signature, @Nullable ExecutionContext exCtx) {
+        logger.info("Transferring {} of {} from {} to {}", quantity, asset.assetId, source.finId, destination.finId);
+        LedgerDetails details = details(idempotencyKey, null, "transfer", exCtx);
+
+        // Local-to-local: a single atomic move in the ledger.
+        if (destination.account instanceof FinIdAccount) {
+            storage.ensureAccount(destination.finId, asset.assetId, asset.assetType.name().toLowerCase());
+            LedgerTransaction tx = storage.move(source.finId, destination.finId, quantity, asset.assetId, details,
+                    asset.assetType.name().toLowerCase());
+            return new SuccessReceiptStatus(buildReceipt(tx, OperationType.TRANSFER, asset, source, destination,
+                    quantity, exCtx, null, null));
+        }
+
+        // External destination: lock → outbound transfer → unlockAndDebit on success, unlock on failure.
+        if (transferDelegate == null) {
+            return new FailedReceiptStatus(new ErrorDetails(1, "External transfer requires a transfer delegate"));
+        }
+        storage.lock(source.finId, quantity, asset.assetId, details.withIdempotencyKey(idempotencyKey + ":hold"),
+                asset.assetType.name().toLowerCase());
+
+        DelegateResult ext = transferDelegate.outboundTransfer(idempotencyKey, source, destination, asset, quantity, exCtx);
+        if (!ext.success) {
+            storage.unlock(source.finId, quantity, asset.assetId,
+                    details.withIdempotencyKey(idempotencyKey + ":unlock"),
+                    asset.assetType.name().toLowerCase());
+            return new FailedReceiptStatus(new ErrorDetails(1, ext.error != null ? ext.error : "outbound transfer failed"));
+        }
+        LedgerTransaction tx = storage.unlockAndDebit(source.finId, quantity, asset.assetId,
+                details.withIdempotencyKey(idempotencyKey + ":debit"),
+                asset.assetType.name().toLowerCase());
+        return new SuccessReceiptStatus(buildReceipt(tx, OperationType.TRANSFER, asset, source, destination,
+                quantity, exCtx, null, ext.transactionId));
+    }
+
+    @Override
+    public ReceiptOperation redeem(String idempotencyKey, String nonce, FinIdAccount source, Asset asset,
+                                   String quantity, @Nullable String operationId, Signature signature,
+                                   @Nullable ExecutionContext exCtx) {
+        logger.info("Redeeming {} of {} from {}", quantity, asset.assetId, source.finId);
+        LedgerDetails details = details(idempotencyKey, operationId, "redeem", exCtx);
+        // If operationId is set, this redeem is finalizing a prior hold (unlock + debit in one
+        // atomic step); otherwise it's a straight debit from available funds.
+        LedgerTransaction tx = operationId != null
+                ? storage.unlockAndDebit(source.finId, quantity, asset.assetId, details, asset.assetType.name().toLowerCase())
+                : storage.debit(source.finId, quantity, asset.assetId, details, asset.assetType.name().toLowerCase());
+        Receipt receipt = buildReceipt(tx, OperationType.REDEEM, asset,
+                new Source(source.finId, new FinIdAccount(source.finId)), null, quantity, exCtx, operationId, null);
+        return new SuccessReceiptStatus(receipt);
+    }
+
+    @Override
+    public String getBalance(Asset asset, String finId) {
+        return storage.getBalance(finId, asset.assetId, asset.assetType.name().toLowerCase()).available;
+    }
+
+    @Override
+    public Balance balance(Asset asset, String finId) {
+        LedgerBalance b = storage.getBalance(finId, asset.assetId, asset.assetType.name().toLowerCase());
+        return new Balance(b.balance, b.available, b.held);
+    }
+
+    // ─── EscrowService ──────────────────────────────────────────────────────
+
+    @Override
+    public ReceiptOperation hold(String idempotencyKey, String nonce, Source source,
+                                 @Nullable Destination destination, Asset asset,
+                                 String quantity, Signature signature, String operationId,
+                                 @Nullable ExecutionContext exCtx) {
+        logger.info("Hold {} of {} on {}", quantity, asset.assetId, source.finId);
+        LedgerDetails details = details(idempotencyKey, operationId, "hold", exCtx);
+        LedgerTransaction tx = storage.lock(source.finId, quantity, asset.assetId, details,
+                asset.assetType.name().toLowerCase());
+
+        String externalTxId = null;
+        if (escrowDelegate != null) {
+            DelegateResult ext = escrowDelegate.hold(idempotencyKey, source, destination, asset, quantity, operationId, exCtx);
+            if (!ext.success) {
+                storage.unlock(source.finId, quantity, asset.assetId,
+                        details.withIdempotencyKey(idempotencyKey + ":unlock"),
+                        asset.assetType.name().toLowerCase());
+                return new FailedReceiptStatus(new ErrorDetails(1, ext.error != null ? ext.error : "external hold failed"));
+            }
+            externalTxId = ext.transactionId;
+        }
+        return new SuccessReceiptStatus(buildReceipt(tx, OperationType.HOLD, asset, source, destination,
+                quantity, exCtx, operationId, externalTxId));
+    }
+
+    @Override
+    public ReceiptOperation release(String idempotencyKey, Source source, Destination destination,
+                                    Asset asset, String quantity, String operationId,
+                                    @Nullable ExecutionContext exCtx) {
+        logger.info("Release {} of {} from {} to {}", quantity, asset.assetId, source.finId, destination.finId);
+        LedgerDetails details = details(idempotencyKey, operationId, "release", exCtx);
+
+        // Delegate first: if the external release fails, the funds stay held locally so the
+        // operator can retry (matches Node's ordering and comment).
+        String externalTxId = null;
+        if (escrowDelegate != null) {
+            DelegateResult ext = escrowDelegate.release(idempotencyKey, source, destination, asset, quantity, operationId, exCtx);
+            if (!ext.success) {
+                return new FailedReceiptStatus(new ErrorDetails(1, ext.error != null ? ext.error : "external release failed"));
+            }
+            externalTxId = ext.transactionId;
+        }
+        storage.ensureAccount(destination.finId, asset.assetId, asset.assetType.name().toLowerCase());
+        LedgerTransaction tx = storage.unlockAndMove(source.finId, destination.finId, quantity, asset.assetId, details,
+                asset.assetType.name().toLowerCase());
+        return new SuccessReceiptStatus(buildReceipt(tx, OperationType.RELEASE, asset, source, destination,
+                quantity, exCtx, operationId, externalTxId));
+    }
+
+    @Override
+    public ReceiptOperation rollback(String idempotencyKey, Source source, Asset asset,
+                                     String quantity, String operationId, @Nullable ExecutionContext exCtx) {
+        logger.info("Rollback {} of {} on {}", quantity, asset.assetId, source.finId);
+        LedgerDetails details = details(idempotencyKey, operationId, "rollback", exCtx);
+        String externalTxId = null;
+        if (escrowDelegate != null) {
+            DelegateResult ext = escrowDelegate.rollback(idempotencyKey, source, asset, quantity, operationId, exCtx);
+            if (!ext.success) {
+                return new FailedReceiptStatus(new ErrorDetails(1, ext.error != null ? ext.error : "external rollback failed"));
+            }
+            externalTxId = ext.transactionId;
+        }
+        LedgerTransaction tx = storage.unlock(source.finId, quantity, asset.assetId, details,
+                asset.assetType.name().toLowerCase());
+        return new SuccessReceiptStatus(buildReceipt(tx, OperationType.ROLLBACK, asset,
+                new Source(source.finId, new FinIdAccount(source.finId)), null, quantity, exCtx, operationId, externalTxId));
+    }
+
+    // ─── CommonService ──────────────────────────────────────────────────────
+
+    @Override
+    public ReceiptOperation getReceipt(String id) {
+        LedgerTransaction tx = storage.getTransaction(id);
+        if (tx == null) {
+            // Try operationId fallback (matches Node lookup order so callers can use either id).
+            tx = storage.findByOperationId(id);
+        }
+        if (tx == null) {
+            return new FailedReceiptStatus(new ErrorDetails(1, "Receipt not found: " + id));
+        }
+        OperationType opType = parseOperationType(tx.details.operationType);
+        Asset asset = new Asset(tx.assetId, parseAssetType(tx.assetType), null);
+        Source source = tx.source != null ? new Source(tx.source, new FinIdAccount(tx.source)) : null;
+        Destination destination = tx.destination != null ? new Destination(tx.destination, new FinIdAccount(tx.destination)) : null;
+        return new SuccessReceiptStatus(buildReceipt(tx, opType, asset, source, destination,
+                tx.amount, executionContextFromDetails(tx.details), tx.details.operationId, null));
+    }
+
+    @Override
+    public OperationStatus operationStatus(String cid) {
+        // Vanilla doesn't run its own workflow store — the workflow proxy in the skeleton owns
+        // cid-keyed lookups (GET /api/operations/status/{cid} reads from operations.outputs
+        // directly). This method exists to satisfy the CommonService contract; calling it
+        // bypasses the durable workflow path and is generally a configuration mistake.
+        throw new UnsupportedOperationException(
+                "operationStatus(cid) is owned by the workflow proxy; poll /api/operations/status/{cid} instead");
+    }
+
+    // ─── HealthService ──────────────────────────────────────────────────────
+
+    @Override
+    public void liveness() {
+        // No external dependencies beyond the ledger DB; a successful storage call proves both
+        // jOOQ and the connection pool are healthy.
+        storage.getBalance("__health__", "__health__");
+    }
+
+    @Override
+    public void readiness() {
+        liveness();
+    }
+
+    // ─── AccountMappingService (delegated to skeleton's impl) ───────────────
+
+    @Override
+    public List<AccountMapping> getAccounts(@Nullable List<String> finIds) {
+        return accountMappingService.getAccounts(finIds);
+    }
+
+    @Override
+    public List<AccountMapping> getByFieldValue(String fieldName, String value) {
+        return accountMappingService.getByFieldValue(fieldName, value);
+    }
+
+    @Override
+    public AccountMapping saveAccount(String finId, Map<String, String> fields) {
+        return accountMappingService.saveAccount(finId, fields);
+    }
+
+    @Override
+    public void deleteAccount(String finId, @Nullable String fieldName) {
+        accountMappingService.deleteAccount(finId, fieldName);
+    }
+
+    // ─── InboundTransferHook ────────────────────────────────────────────────
+
+    @Override
+    public void onPlannedInboundTransfer(String idempotencyKey, PlannedInboundTransferContext ctx) {
+        // Best-effort: pre-create the destination account so the post-execution credit doesn't
+        // race with concurrent ensureAccount on the issue side.
+        storage.ensureAccount(ctx.destination, ctx.asset.assetId, ctx.asset.assetType.name().toLowerCase());
+    }
+
+    @Override
+    public void onInboundTransfer(String idempotencyKey, InboundTransferContext ctx) {
+        // Verify via TransferDelegate.onInboundTransfer if one is wired, then credit the local
+        // destination. A verification failure skips the credit so an unverifiable transfer
+        // can't inflate the destination's balance.
+        if (transferDelegate != null) {
+            Source source = new Source(ctx.source, new FinIdAccount(ctx.source));
+            Destination dest = new Destination(ctx.destination, new FinIdAccount(ctx.destination));
+            try {
+                transferDelegate.onInboundTransfer(
+                        ctx.result != null && ctx.result.transactionId != null ? ctx.result.transactionId : "",
+                        source, ctx.asset, dest, ctx.amount, null);
+            } catch (InboundTransferVerificationError e) {
+                logger.warn("Skipping inbound credit for plan={} dst={} amount={}: {}",
+                        ctx.planId, ctx.destination, ctx.amount, e.getMessage());
+                return;
+            }
+        }
+        storage.ensureAccount(ctx.destination, ctx.asset.assetId, ctx.asset.assetType.name().toLowerCase());
+        storage.credit(ctx.destination, ctx.amount, ctx.asset.assetId,
+                details(idempotencyKey, null, "inboundTransfer", null),
+                ctx.asset.assetType.name().toLowerCase());
+    }
+
+    // ─── Helpers ────────────────────────────────────────────────────────────
+
+    private static LedgerDetails details(String idempotencyKey, @Nullable String operationId,
+                                         String operationType, @Nullable ExecutionContext exCtx) {
+        LedgerDetails.LedgerExecutionContext lec = exCtx != null
+                ? new LedgerDetails.LedgerExecutionContext(exCtx.planId, exCtx.sequence)
+                : null;
+        return new LedgerDetails(idempotencyKey, operationId, operationType, lec, null);
+    }
+
+    private static Receipt buildReceipt(LedgerTransaction tx, OperationType opType, Asset asset,
+                                        @Nullable Source source, @Nullable Destination destination,
+                                        String quantity, @Nullable ExecutionContext exCtx,
+                                        @Nullable String operationId, @Nullable String externalTxId) {
+        TransactionDetails txDetails = new TransactionDetails(
+                externalTxId != null ? externalTxId : tx.id, operationId);
+        TradeDetails tradeDetails = new TradeDetails(exCtx);
+        long timestamp = tx.createdAt.toEpochMilli();
+        ProofPolicy proof = null;
+        return new Receipt(tx.id, opType, asset, source, destination, quantity,
+                txDetails, tradeDetails, proof, timestamp);
+    }
+
+    private static OperationType parseOperationType(@Nullable String opType) {
+        if (opType == null) return OperationType.TRANSFER;
+        switch (opType) {
+            case "issue":    return OperationType.ISSUE;
+            case "transfer": return OperationType.TRANSFER;
+            case "redeem":   return OperationType.REDEEM;
+            case "hold":     return OperationType.HOLD;
+            case "release":  return OperationType.RELEASE;
+            case "rollback": return OperationType.ROLLBACK;
+            default:         return OperationType.TRANSFER;
+        }
+    }
+
+    private static AssetType parseAssetType(@Nullable String t) {
+        if (t == null) return AssetType.FINP2P;
+        try {
+            return AssetType.valueOf(t.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            return AssetType.FINP2P;
+        }
+    }
+
+    @Nullable
+    private static ExecutionContext executionContextFromDetails(LedgerDetails details) {
+        return details.executionContext != null
+                ? new ExecutionContext(details.executionContext.planId, details.executionContext.sequence)
+                : null;
+    }
+
+    private static String generateCid() {
+        byte[] bytes = new byte[32];
+        RNG.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
@@ -342,15 +342,28 @@ public class VanillaServiceImpl implements
 
     @Override
     public void onInboundTransfer(String idempotencyKey, InboundTransferContext ctx) {
-        // Verify via TransferDelegate.onInboundTransfer if one is wired, then credit the local
-        // destination. A verification failure skips the credit so an unverifiable transfer
-        // can't inflate the destination's balance.
+        // Only mint a local credit when the upstream instruction actually produced a successful
+        // receipt. A {@code null} result means the caller doesn't yet know how the instruction
+        // landed (today's DefaultPlanApprovalService still passes null here) — treating that as
+        // success would let the destination's balance inflate without a confirmed inbound. An
+        // {@code ERROR} result means the instruction failed; same skip.
+        if (ctx.result == null
+                || ctx.result.type != InboundTransferHook.InstructionResult.Type.RECEIPT) {
+            logger.warn("Skipping inbound credit for plan={} dst={} amount={}: no successful receipt (result={})",
+                    ctx.planId, ctx.destination, ctx.amount,
+                    ctx.result != null ? ctx.result.type : "null");
+            return;
+        }
+
+        // RECEIPT path: optionally verify via the TransferDelegate, then credit. A
+        // InboundTransferVerificationError thrown by the delegate skips the credit so an
+        // unverifiable transfer can't reach the destination either.
         if (transferDelegate != null) {
             Source source = new Source(ctx.source, new FinIdAccount(ctx.source));
             Destination dest = new Destination(ctx.destination, new FinIdAccount(ctx.destination));
             try {
                 transferDelegate.onInboundTransfer(
-                        ctx.result != null && ctx.result.transactionId != null ? ctx.result.transactionId : "",
+                        ctx.result.transactionId != null ? ctx.result.transactionId : "",
                         source, ctx.asset, dest, ctx.amount, null);
             } catch (InboundTransferVerificationError e) {
                 logger.warn("Skipping inbound credit for plan={} dst={} amount={}: {}",

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
@@ -161,9 +161,12 @@ public class VanillaServiceImpl implements
                     asset.assetType.name().toLowerCase());
             return new FailedReceiptStatus(new ErrorDetails(1, ext.error != null ? ext.error : "outbound transfer failed"));
         }
+        // Final write captures the delegate's external tx id + counterparty account shapes so a
+        // later getReceipt() can reproduce the same receipt the caller received here.
+        LedgerDetails finalDetails = details(idempotencyKey + ":debit", null, "transfer", exCtx,
+                source, destination, ext.transactionId);
         LedgerTransaction tx = storage.unlockAndDebit(source.finId, quantity, asset.assetId,
-                details.withIdempotencyKey(idempotencyKey + ":debit"),
-                asset.assetType.name().toLowerCase());
+                finalDetails, asset.assetType.name().toLowerCase());
         return new SuccessReceiptStatus(buildReceipt(tx, OperationType.TRANSFER, asset, source, destination,
                 quantity, exCtx, null, ext.transactionId));
     }
@@ -227,7 +230,6 @@ public class VanillaServiceImpl implements
                                     Asset asset, String quantity, String operationId,
                                     @Nullable ExecutionContext exCtx) {
         logger.info("Release {} of {} from {} to {}", quantity, asset.assetId, source.finId, destination.finId);
-        LedgerDetails details = details(idempotencyKey, operationId, "release", exCtx);
 
         // Delegate first: if the external release fails, the funds stay held locally so the
         // operator can retry (matches Node's ordering and comment).
@@ -239,6 +241,10 @@ public class VanillaServiceImpl implements
             }
             externalTxId = ext.transactionId;
         }
+        // The storage row carries the external tx id + counterparty account shapes so
+        // getReceipt() can reproduce this receipt later.
+        LedgerDetails details = details(idempotencyKey, operationId, "release", exCtx,
+                source, destination, externalTxId);
         storage.ensureAccount(destination.finId, asset.assetId, asset.assetType.name().toLowerCase());
         LedgerTransaction tx = storage.unlockAndMove(source.finId, destination.finId, quantity, asset.assetId, details,
                 asset.assetType.name().toLowerCase());
@@ -250,7 +256,6 @@ public class VanillaServiceImpl implements
     public ReceiptOperation rollback(String idempotencyKey, Source source, Asset asset,
                                      String quantity, String operationId, @Nullable ExecutionContext exCtx) {
         logger.info("Rollback {} of {} on {}", quantity, asset.assetId, source.finId);
-        LedgerDetails details = details(idempotencyKey, operationId, "rollback", exCtx);
         String externalTxId = null;
         if (escrowDelegate != null) {
             DelegateResult ext = escrowDelegate.rollback(idempotencyKey, source, asset, quantity, operationId, exCtx);
@@ -259,6 +264,8 @@ public class VanillaServiceImpl implements
             }
             externalTxId = ext.transactionId;
         }
+        LedgerDetails details = details(idempotencyKey, operationId, "rollback", exCtx,
+                source, null, externalTxId);
         LedgerTransaction tx = storage.unlock(source.finId, quantity, asset.assetId, details,
                 asset.assetType.name().toLowerCase());
         return new SuccessReceiptStatus(buildReceipt(tx, OperationType.ROLLBACK, asset,
@@ -279,10 +286,38 @@ public class VanillaServiceImpl implements
         }
         OperationType opType = parseOperationType(tx.details.operationType);
         Asset asset = new Asset(tx.assetId, parseAssetType(tx.assetType), null);
-        Source source = tx.source != null ? new Source(tx.source, new FinIdAccount(tx.source)) : null;
-        Destination destination = tx.destination != null ? new Destination(tx.destination, new FinIdAccount(tx.destination)) : null;
+        // Reconstruct the counterparty shapes from details. A delegate-backed row carries a
+        // LedgerAccountRef in details (finId + wallet type/address) when the counterparty isn't
+        // a vanilla-tracked FinId — that ref is the only place an external counterparty's finId
+        // survives, because storage.unlockAndDebit and friends are single-sided writes whose
+        // row's source/destination column holds only the local side.
+        Source source = rehydrateSource(tx.source, tx.details.sourceAccount);
+        Destination destination = rehydrateDestination(tx.destination, tx.details.destinationAccount);
         return new SuccessReceiptStatus(buildReceipt(tx, opType, asset, source, destination,
-                tx.amount, executionContextFromDetails(tx.details), tx.details.operationId, null));
+                tx.amount, executionContextFromDetails(tx.details), tx.details.operationId,
+                tx.details.transactionId));
+    }
+
+    private static @Nullable Source rehydrateSource(@Nullable String rowFinId,
+                                                    @Nullable LedgerDetails.LedgerAccountRef ref) {
+        if (ref != null) {
+            return new Source(ref.finId, new io.ownera.ledger.adapter.service.model.LedgerAccount(ref.type, ref.address));
+        }
+        if (rowFinId != null) {
+            return new Source(rowFinId, new FinIdAccount(rowFinId));
+        }
+        return null;
+    }
+
+    private static @Nullable Destination rehydrateDestination(@Nullable String rowFinId,
+                                                              @Nullable LedgerDetails.LedgerAccountRef ref) {
+        if (ref != null) {
+            return new Destination(ref.finId, new io.ownera.ledger.adapter.service.model.LedgerAccount(ref.type, ref.address));
+        }
+        if (rowFinId != null) {
+            return new Destination(rowFinId, new FinIdAccount(rowFinId));
+        }
+        return null;
     }
 
     @Override
@@ -381,10 +416,50 @@ public class VanillaServiceImpl implements
 
     private static LedgerDetails details(String idempotencyKey, @Nullable String operationId,
                                          String operationType, @Nullable ExecutionContext exCtx) {
+        return details(idempotencyKey, operationId, operationType, exCtx, null, null, null);
+    }
+
+    /**
+     * Rich details builder for the delegate-backed paths: captures the external transaction id
+     * and the non-FinId account shapes so a later {@link #getReceipt(String)} can reproduce the
+     * same receipt that was returned to the caller.
+     */
+    private static LedgerDetails details(String idempotencyKey, @Nullable String operationId,
+                                         String operationType, @Nullable ExecutionContext exCtx,
+                                         @Nullable Source source, @Nullable Destination destination,
+                                         @Nullable String externalTransactionId) {
         LedgerDetails.LedgerExecutionContext lec = exCtx != null
                 ? new LedgerDetails.LedgerExecutionContext(exCtx.planId, exCtx.sequence)
                 : null;
-        return new LedgerDetails(idempotencyKey, operationId, operationType, lec, null);
+        return new LedgerDetails(idempotencyKey, operationId, operationType, lec,
+                externalTransactionId,
+                sourceAccountRef(source),
+                destinationAccountRef(destination));
+    }
+
+    /** Captures a source counterparty's finId + (when not a FinIdAccount) the wallet shape. */
+    private static @Nullable LedgerDetails.LedgerAccountRef sourceAccountRef(@Nullable Source source) {
+        if (source == null) return null;
+        if (source.account instanceof io.ownera.ledger.adapter.service.model.LedgerAccount) {
+            io.ownera.ledger.adapter.service.model.LedgerAccount la =
+                    (io.ownera.ledger.adapter.service.model.LedgerAccount) source.account;
+            return new LedgerDetails.LedgerAccountRef(source.finId, la.type, la.address);
+        }
+        return null;
+    }
+
+    /** Captures a destination counterparty's finId + (when not a FinIdAccount) the wallet shape.
+     *  For an external transfer the destination's finId is not stored in the row's
+     *  {@code destination} column (the storage write is single-sided), so this is the only
+     *  place it survives. */
+    private static @Nullable LedgerDetails.LedgerAccountRef destinationAccountRef(@Nullable Destination destination) {
+        if (destination == null) return null;
+        if (destination.account instanceof io.ownera.ledger.adapter.service.model.LedgerAccount) {
+            io.ownera.ledger.adapter.service.model.LedgerAccount la =
+                    (io.ownera.ledger.adapter.service.model.LedgerAccount) destination.account;
+            return new LedgerDetails.LedgerAccountRef(destination.finId, la.type, la.address);
+        }
+        return null;
     }
 
     private static Receipt buildReceipt(LedgerTransaction tx, OperationType opType, Asset asset,

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImpl.java
@@ -390,6 +390,12 @@ public class VanillaServiceImpl implements
             return;
         }
 
+        // Hand the delegate (and the storage row) the upstream execution context so
+        // verification has plan / instruction info, and a later getReceipt() can round-trip
+        // the same planId / sequence Node persists.
+        ExecutionContext exCtx = new ExecutionContext(ctx.planId, ctx.instructionSequence);
+        String upstreamTxId = ctx.result.transactionId != null ? ctx.result.transactionId : "";
+
         // RECEIPT path: optionally verify via the TransferDelegate, then credit. A
         // InboundTransferVerificationError thrown by the delegate skips the credit so an
         // unverifiable transfer can't reach the destination either.
@@ -397,9 +403,7 @@ public class VanillaServiceImpl implements
             Source source = new Source(ctx.source, new FinIdAccount(ctx.source));
             Destination dest = new Destination(ctx.destination, new FinIdAccount(ctx.destination));
             try {
-                transferDelegate.onInboundTransfer(
-                        ctx.result.transactionId != null ? ctx.result.transactionId : "",
-                        source, ctx.asset, dest, ctx.amount, null);
+                transferDelegate.onInboundTransfer(upstreamTxId, source, ctx.asset, dest, ctx.amount, exCtx);
             } catch (InboundTransferVerificationError e) {
                 logger.warn("Skipping inbound credit for plan={} dst={} amount={}: {}",
                         ctx.planId, ctx.destination, ctx.amount, e.getMessage());
@@ -407,8 +411,11 @@ public class VanillaServiceImpl implements
             }
         }
         storage.ensureAccount(ctx.destination, ctx.asset.assetId, ctx.asset.assetType.name().toLowerCase());
-        storage.credit(ctx.destination, ctx.amount, ctx.asset.assetId,
-                details(idempotencyKey, null, "inboundTransfer", null),
+        // Persist the upstream transaction id + execution context in details so a later
+        // getReceipt() reproduces the upstream provenance, matching Node's parity behavior.
+        LedgerDetails credited = details(idempotencyKey, null, "inboundTransfer", exCtx,
+                null, null, ctx.result.transactionId);
+        storage.credit(ctx.destination, ctx.amount, ctx.asset.assetId, credited,
                 ctx.asset.assetType.name().toLowerCase());
     }
 

--- a/vanilla-service/src/main/resources/db/migration/vanilla/V3001__create_vanilla_ledger.sql
+++ b/vanilla-service/src/main/resources/db/migration/vanilla/V3001__create_vanilla_ledger.sql
@@ -1,0 +1,46 @@
+-- Vanilla service per-investor ledger.
+--
+-- Assumes the schema already exists (created by the skeleton's V1001 migration).
+-- Adds two tables:
+--   * accounts      — (fin_id, asset_id, asset_type) UNIQUE; balance + held with CHECK
+--                     constraints so held never exceeds balance.
+--   * transactions  — append-only ledger of credits, debits, locks, moves, etc., with
+--                     idempotency keyed off details->>'idempotency_key'.
+--
+-- Mirrors the Node vanilla-service migration (vanilla-service/migrations/20260310000000_add_vanilla_ledger.sql).
+
+CREATE TABLE IF NOT EXISTS ${schema_name}.accounts (
+    id         BIGSERIAL PRIMARY KEY,
+    fin_id     VARCHAR(255) NOT NULL,
+    asset_id   VARCHAR(255) NOT NULL,
+    asset_type VARCHAR(64)  NOT NULL DEFAULT 'finp2p',
+    balance    NUMERIC      NOT NULL DEFAULT 0,
+    held       NUMERIC      NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE (fin_id, asset_id, asset_type),
+    CHECK (balance >= 0),
+    CHECK (held >= 0 AND held <= balance)
+);
+
+CREATE TABLE IF NOT EXISTS ${schema_name}.transactions (
+    id               VARCHAR(50)  PRIMARY KEY,
+    asset_id         VARCHAR(255) NOT NULL,
+    asset_type       VARCHAR(64)  NOT NULL DEFAULT 'finp2p',
+    source           VARCHAR(255),
+    destination      VARCHAR(255),
+    amount           NUMERIC      NOT NULL DEFAULT 0,
+    source_held      NUMERIC      NOT NULL DEFAULT 0,
+    destination_held NUMERIC      NOT NULL DEFAULT 0,
+    action           VARCHAR(64)  NOT NULL,
+    details          JSONB        NOT NULL DEFAULT '{}',
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Idempotency: the storage layer's CTE checks for an existing tx by this expression before
+-- mutating any account, so the same idempotency_key returns the original tx row.
+CREATE UNIQUE INDEX IF NOT EXISTS tx_idempotency_idx
+    ON ${schema_name}.transactions ((details->>'idempotency_key'));
+
+CREATE INDEX IF NOT EXISTS tx_operation_idx
+    ON ${schema_name}.transactions ((details->>'operation_id'));

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
@@ -226,4 +226,33 @@ class LedgerStorageTest {
         assertNotNull(found);
         assertEquals(created.id, found.id);
     }
+
+    @Test
+    void findByOperationIdReturnsLatestWhenMultipleRowsShareOperationId() throws Exception {
+        // hold + release + redeem all stamp the caller's operation_id into details, so the
+        // same id legitimately appears on multiple ledger rows. Before this fix, fetchOne()
+        // threw TooManyRowsException once more than one row matched. Now the query returns
+        // the most-recent row (the terminating event).
+        String src = "fin-" + System.nanoTime();
+        String dst = "fin-dst-" + System.nanoTime();
+        String assetId = "asset-multi-" + System.nanoTime();
+        storage.ensureAccount(src, assetId);
+        storage.ensureAccount(dst, assetId);
+        storage.credit(src, "100", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+        String opId = "op-multi-" + System.nanoTime();
+
+        LedgerTransaction holdTx = storage.lock(src, "40", assetId,
+                new LedgerDetails("ik-h-" + System.nanoTime(), opId, "hold", null, null));
+        // Ensure created_at timestamps are distinguishable; the secondary id DESC tiebreaker
+        // covers the same-tick case but we want to exercise the timestamp branch here.
+        Thread.sleep(5);
+        LedgerTransaction releaseTx = storage.unlockAndMove(src, dst, "40", assetId,
+                new LedgerDetails("ik-r-" + System.nanoTime(), opId, "release", null, null));
+
+        LedgerTransaction found = storage.findByOperationId(opId);
+        assertNotNull(found);
+        assertEquals(releaseTx.id, found.id,
+                "duplicate operation_id must resolve to the most-recent event, not throw");
+        assertNotEquals(holdTx.id, found.id);
+    }
 }

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
@@ -1,0 +1,229 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.BusinessException;
+import org.jooq.DSLContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for {@link LedgerStorage} against a real Postgres instance via Testcontainers.
+ * Covers each balance-mutating operation, idempotency, and CHECK-constraint enforcement.
+ */
+class LedgerStorageTest {
+
+    private static final DSLContext CTX = VanillaPostgresHolder.CTX;
+    private LedgerStorage storage;
+
+    @BeforeEach
+    void setup() {
+        storage = new LedgerStorage(CTX, VanillaPostgresHolder.SCHEMA);
+    }
+
+    private LedgerDetails details(String key, String operationType) {
+        return new LedgerDetails(key, null, operationType, null, null);
+    }
+
+    @Test
+    void rejectsInvalidSchemaName() {
+        assertThrows(IllegalArgumentException.class, () -> new LedgerStorage(CTX, "bad name"));
+        assertThrows(IllegalArgumentException.class, () -> new LedgerStorage(CTX, "drop;table"));
+        assertThrows(IllegalArgumentException.class, () -> new LedgerStorage(CTX, ""));
+    }
+
+    @Test
+    void getBalanceReturnsZeroForUnknownAccount() {
+        LedgerBalance b = storage.getBalance("unknown-" + System.nanoTime(), "asset-X");
+        assertEquals("0", b.balance);
+        assertEquals("0", b.held);
+        assertEquals("0", b.available);
+    }
+
+    @Test
+    void creditIncreasesBalanceAndReturnsTxRow() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+
+        LedgerTransaction tx = storage.credit(finId, "100", assetId, details("ik-credit-" + System.nanoTime(), "issue"));
+        assertEquals(finId, tx.destination);
+        assertNull(tx.source);
+        assertEquals("100", tx.amount);
+        assertEquals("credit", tx.action);
+
+        LedgerBalance b = storage.getBalance(finId, assetId);
+        assertEquals("100", b.balance);
+        assertEquals("0", b.held);
+        assertEquals("100", b.available);
+    }
+
+    @Test
+    void debitDecreasesBalance() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        storage.credit(finId, "50", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+
+        storage.debit(finId, "20", assetId, details("ik-d-" + System.nanoTime(), "redeem"));
+
+        assertEquals("30", storage.getBalance(finId, assetId).balance);
+    }
+
+    @Test
+    void lockMovesAvailableIntoHeld() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        storage.credit(finId, "100", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+
+        storage.lock(finId, "40", assetId, details("ik-l-" + System.nanoTime(), "hold"));
+
+        LedgerBalance b = storage.getBalance(finId, assetId);
+        assertEquals("100", b.balance);
+        assertEquals("40", b.held);
+        assertEquals("60", b.available);
+    }
+
+    @Test
+    void unlockReturnsHeldToAvailable() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        storage.credit(finId, "100", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+        storage.lock(finId, "40", assetId, details("ik-l-" + System.nanoTime(), "hold"));
+
+        storage.unlock(finId, "40", assetId, details("ik-u-" + System.nanoTime(), "rollback"));
+
+        LedgerBalance b = storage.getBalance(finId, assetId);
+        assertEquals("0", b.held);
+        assertEquals("100", b.available);
+    }
+
+    @Test
+    void moveTransfersBetweenAccounts() {
+        String src = "fin-src-" + System.nanoTime();
+        String dst = "fin-dst-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(src, assetId);
+        storage.ensureAccount(dst, assetId);
+        storage.credit(src, "100", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+
+        storage.move(src, dst, "60", assetId, details("ik-m-" + System.nanoTime(), "transfer"));
+
+        assertEquals("40", storage.getBalance(src, assetId).balance);
+        assertEquals("60", storage.getBalance(dst, assetId).balance);
+    }
+
+    @Test
+    void moveRejectsSelfMove() {
+        String finId = "fin-self-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        BusinessException e = assertThrows(BusinessException.class, () ->
+                storage.move(finId, finId, "10", assetId,
+                        details("ik-self-" + System.nanoTime(), "transfer")));
+        assertTrue(e.getMessage().contains(finId));
+    }
+
+    @Test
+    void unlockAndMoveReleasesHoldAndTransfers() {
+        String src = "fin-src-" + System.nanoTime();
+        String dst = "fin-dst-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(src, assetId);
+        storage.ensureAccount(dst, assetId);
+        storage.credit(src, "100", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+        storage.lock(src, "70", assetId, details("ik-l-" + System.nanoTime(), "hold"));
+
+        storage.unlockAndMove(src, dst, "70", assetId,
+                details("ik-um-" + System.nanoTime(), "release"));
+
+        assertEquals("30", storage.getBalance(src, assetId).balance);
+        assertEquals("0", storage.getBalance(src, assetId).held);
+        assertEquals("70", storage.getBalance(dst, assetId).balance);
+    }
+
+    @Test
+    void unlockAndDebitReleasesHoldAndDebits() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        storage.credit(finId, "100", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+        storage.lock(finId, "30", assetId, details("ik-l-" + System.nanoTime(), "hold"));
+
+        storage.unlockAndDebit(finId, "30", assetId,
+                details("ik-ud-" + System.nanoTime(), "redeem"));
+
+        LedgerBalance b = storage.getBalance(finId, assetId);
+        assertEquals("70", b.balance);
+        assertEquals("0", b.held);
+    }
+
+    @Test
+    void duplicateIdempotencyKeyReturnsOriginalTxWithoutMutating() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        String ik = "ik-dup-" + System.nanoTime();
+
+        LedgerTransaction first = storage.credit(finId, "50", assetId, details(ik, "issue"));
+        LedgerTransaction second = storage.credit(finId, "50", assetId, details(ik, "issue"));
+
+        assertEquals(first.id, second.id, "duplicate idempotency key must return the original tx");
+        assertEquals("50", storage.getBalance(finId, assetId).balance,
+                "duplicate must NOT credit a second time");
+    }
+
+    @Test
+    void overdraftViolatesBalanceCheckConstraint() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        storage.credit(finId, "10", assetId, details("ik-c-" + System.nanoTime(), "issue"));
+
+        BusinessException e = assertThrows(BusinessException.class, () ->
+                storage.debit(finId, "20", assetId, details("ik-overdraft-" + System.nanoTime(), "redeem")));
+        assertTrue(e.getMessage().toLowerCase().contains("insufficient"), e.getMessage());
+        // The original 10 stays put.
+        assertEquals("10", storage.getBalance(finId, assetId).balance);
+    }
+
+    @Test
+    void getTransactionRoundTripsAllFields() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        String ik = "ik-rt-" + System.nanoTime();
+        LedgerDetails d = new LedgerDetails(ik, "op-42", "issue",
+                new LedgerDetails.LedgerExecutionContext("plan-1", 7), null);
+
+        LedgerTransaction created = storage.credit(finId, "100", assetId, d);
+        LedgerTransaction loaded = storage.getTransaction(created.id);
+        assertNotNull(loaded);
+        assertEquals(created.id, loaded.id);
+        assertEquals("100", loaded.amount);
+        assertEquals("credit", loaded.action);
+        assertEquals(ik, loaded.details.idempotencyKey);
+        assertEquals("op-42", loaded.details.operationId);
+        assertEquals("issue", loaded.details.operationType);
+        assertNotNull(loaded.details.executionContext);
+        assertEquals("plan-1", loaded.details.executionContext.planId);
+        assertEquals(7, loaded.details.executionContext.sequence);
+    }
+
+    @Test
+    void findByOperationIdLooksUpByOperationIdInDetails() {
+        String finId = "fin-" + System.nanoTime();
+        String assetId = "asset-" + System.nanoTime();
+        storage.ensureAccount(finId, assetId);
+        String opId = "op-" + System.nanoTime();
+
+        LedgerTransaction created = storage.credit(finId, "5", assetId,
+                new LedgerDetails("ik-op-" + System.nanoTime(), opId, "issue", null, null));
+
+        LedgerTransaction found = storage.findByOperationId(opId);
+        assertNotNull(found);
+        assertEquals(created.id, found.id);
+    }
+}

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaPostgresHolder.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaPostgresHolder.java
@@ -1,0 +1,55 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import org.flywaydb.core.Flyway;
+import org.jooq.DSLContext;
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Shared Postgres container + DSLContext + ledger schema for vanilla-service tests.
+ *
+ * <p>Boots a Postgres container once per JVM (Testcontainers caches it), runs both the
+ * skeleton's migrations (so the operations/account_mappings schema exists) and the vanilla
+ * V3001 migration (accounts + transactions), and exposes a {@link DSLContext} the tests can
+ * share. Each test isolates itself by using a freshly-namespaced schema or by inserting rows
+ * with unique fin_ids.
+ */
+public final class VanillaPostgresHolder {
+
+    public static final String SCHEMA = "vanilla_test";
+
+    public static final PostgreSQLContainer<?> POSTGRES =
+            new PostgreSQLContainer<>("postgres:16-alpine")
+                    .withDatabaseName("vanilla_test")
+                    .withUsername("test")
+                    .withPassword("test");
+
+    public static final DSLContext CTX;
+
+    static {
+        POSTGRES.start();
+        PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setUrl(POSTGRES.getJdbcUrl());
+        ds.setUser(POSTGRES.getUsername());
+        ds.setPassword(POSTGRES.getPassword());
+        CTX = DSL.using(ds, SQLDialect.POSTGRES);
+        Map<String, String> placeholders = new HashMap<>();
+        placeholders.put("schema_name", SCHEMA);
+        // Skeleton's R__grant_ledger_user.sql expects a ledger_user; tests use the same role
+        // that runs migrations (no separation of admin/runtime users at this layer).
+        placeholders.put("ledger_user", POSTGRES.getUsername());
+        Flyway.configure()
+                .dataSource(ds)
+                .locations("classpath:db/migration/skeleton", "classpath:db/migration/vanilla")
+                .placeholders(placeholders)
+                .load()
+                .migrate();
+    }
+
+    private VanillaPostgresHolder() {}
+}

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
@@ -315,6 +315,35 @@ class VanillaServiceImplTest {
     }
 
     @Test
+    void getReceiptByOperationIdReturnsLatestEventAfterHoldRelease() throws Exception {
+        // Reviewer-flagged: hold and release both stamp the same operation_id into the ledger
+        // details JSONB, so by release time there are two rows sharing that id. The fallback
+        // lookup by operation_id (when the primary tx-id lookup misses) must return the
+        // terminating event — and crucially must not throw on multiple matches.
+        String src = "fin-src-" + System.nanoTime();
+        String dst = "fin-dst-" + System.nanoTime();
+        Asset a = asset("ast-lifecycle-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+        String opId = "op-lifecycle-" + System.nanoTime();
+        svc.hold(uniqueIk("ik-h"), "n",
+                new Source(src, new FinIdAccount(src)), null, a, "40", sig(), opId, null);
+        Thread.sleep(5); // ensure timestamps differ so the ORDER BY is exercised
+        ReceiptOperation releaseOp = svc.release(uniqueIk("ik-r"),
+                new Source(src, new FinIdAccount(src)),
+                new Destination(dst, new FinIdAccount(dst)), a, "40", opId, null);
+        String releaseTxId = ((SuccessReceiptStatus) releaseOp).receipt.id;
+
+        // Calling getReceipt with the operationId (not the tx id) must succeed and resolve to
+        // the release receipt — the latest event in the lifecycle.
+        ReceiptOperation looked = svc.getReceipt(opId);
+        assertTrue(looked instanceof SuccessReceiptStatus,
+                "lookup by operation_id with multiple matches must not throw, got " + looked);
+        assertEquals(releaseTxId, ((SuccessReceiptStatus) looked).receipt.id,
+                "fallback by operation_id must return the most-recent (release) event");
+    }
+
+    @Test
     void operationStatusThrowsBecauseWorkflowProxyOwnsCidLookups() {
         assertThrows(UnsupportedOperationException.class, () -> service().operationStatus("any"));
     }

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
@@ -372,6 +372,35 @@ class VanillaServiceImplTest {
     }
 
     @Test
+    void onInboundTransferSkipsCreditWhenResultIsNull() {
+        // Today's plan service passes ctx.result = null (instruction outcome not yet known).
+        // The hook must treat that as "no confirmed inbound" and skip the credit.
+        String dst = "fin-in-null-" + System.nanoTime();
+        Asset a = asset("ast-in-null-" + System.nanoTime());
+        InboundTransferHook.InboundTransferContext ctx = new InboundTransferHook.InboundTransferContext(
+                "plan-1", "fin-src", a, dst, "50", 0, null);
+
+        service().onInboundTransfer(uniqueIk("ik"), ctx);
+
+        assertEquals("0", storage.getBalance(dst, a.assetId).balance,
+                "null instruction result must not mint a local credit");
+    }
+
+    @Test
+    void onInboundTransferSkipsCreditWhenResultIsError() {
+        String dst = "fin-in-err-" + System.nanoTime();
+        Asset a = asset("ast-in-err-" + System.nanoTime());
+        InboundTransferHook.InboundTransferContext ctx = new InboundTransferHook.InboundTransferContext(
+                "plan-1", "fin-src", a, dst, "50", 0,
+                InboundTransferHook.InstructionResult.error(1, "boom"));
+
+        service().onInboundTransfer(uniqueIk("ik"), ctx);
+
+        assertEquals("0", storage.getBalance(dst, a.assetId).balance,
+                "failed instruction result must not mint a local credit");
+    }
+
+    @Test
     void onInboundTransferSkipsCreditWhenDelegateThrowsVerificationError() {
         String dst = "fin-in-" + System.nanoTime();
         Asset a = asset("ast-in-skip-" + System.nanoTime());

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
@@ -1,0 +1,363 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.mapping.AccountMappingService;
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.AssetBind;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import io.ownera.ledger.adapter.service.model.Balance;
+import io.ownera.ledger.adapter.service.model.Destination;
+import io.ownera.ledger.adapter.service.model.ExecutionContext;
+import io.ownera.ledger.adapter.service.model.FailedReceiptStatus;
+import io.ownera.ledger.adapter.service.model.FinIdAccount;
+import io.ownera.ledger.adapter.service.model.OperationType;
+import io.ownera.ledger.adapter.service.model.ReceiptOperation;
+import io.ownera.ledger.adapter.service.model.Signature;
+import io.ownera.ledger.adapter.service.model.Source;
+import io.ownera.ledger.adapter.service.model.SuccessReceiptStatus;
+import io.ownera.ledger.adapter.service.model.SuccessfulAssetCreation;
+import io.ownera.ledger.adapter.service.model.AssetCreationStatus;
+import io.ownera.ledger.adapter.service.model.TokenIdentifier;
+import io.ownera.ledger.adapter.service.plan.InboundTransferHook;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for {@link VanillaServiceImpl}: each service-interface method exercised
+ * against the real {@link LedgerStorage}, with delegate hooks driven by Mockito so failure
+ * branches and external-transfer ordering can be observed without a live external system.
+ */
+class VanillaServiceImplTest {
+
+    private LedgerStorage storage;
+    private AccountMappingService mapping;
+
+    @BeforeEach
+    void setup() {
+        storage = new LedgerStorage(VanillaPostgresHolder.CTX, VanillaPostgresHolder.SCHEMA);
+        mapping = Mockito.mock(AccountMappingService.class);
+    }
+
+    private VanillaServiceImpl service() {
+        return new VanillaServiceImpl(storage, mapping);
+    }
+
+    private VanillaServiceImpl service(AssetDelegate ad, TransferDelegate td, EscrowDelegate ed) {
+        return new VanillaServiceImpl(storage, mapping, ad, td, ed);
+    }
+
+    private static Asset asset(String id) {
+        return new Asset(id, AssetType.FINP2P);
+    }
+
+    private static Signature sig() {
+        return null; // signatures are validated by the controller layer, not vanilla
+    }
+
+    private static String uniqueIk(String prefix) {
+        return prefix + "-" + System.nanoTime();
+    }
+
+    // ─── TokenService ───────────────────────────────────────────────────────
+
+    @Test
+    void createAssetWithoutDelegateMintsSyntheticCaip19() {
+        AssetCreationStatus s = service().createAsset(uniqueIk("ik"), asset("ast-X"),
+                null, null, null, null, null);
+        assertTrue(s instanceof SuccessfulAssetCreation);
+        SuccessfulAssetCreation success = (SuccessfulAssetCreation) s;
+        assertNotNull(success.result.tokenId);
+        assertFalse(success.result.tokenId.isEmpty());
+        assertEquals("db", success.result.reference.network);
+        assertEquals("vanilla", success.result.reference.tokenStandard);
+    }
+
+    @Test
+    void createAssetWithDelegatePassesThrough() {
+        io.ownera.ledger.adapter.service.model.AssetCreationResult expected =
+                new io.ownera.ledger.adapter.service.model.AssetCreationResult("EXT-123",
+                        new io.ownera.ledger.adapter.service.model.LedgerReference("hedera:testnet", "0x0", "HTS", null));
+        AssetDelegate delegate = Mockito.mock(AssetDelegate.class);
+        Mockito.when(delegate.createAsset(Mockito.anyString(), Mockito.eq("ast-Y"),
+                Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any()))
+                .thenReturn(expected);
+
+        AssetCreationStatus s = service(delegate, null, null).createAsset(
+                uniqueIk("ik"), asset("ast-Y"), null, null, null, null, null);
+        assertTrue(s instanceof SuccessfulAssetCreation);
+        assertEquals("EXT-123", ((SuccessfulAssetCreation) s).result.tokenId);
+    }
+
+    @Test
+    void createAssetWithBindPreservesTokenId() {
+        AssetBind bind = new AssetBind(new TokenIdentifier("tok-bound"));
+        AssetCreationStatus s = service().createAsset(uniqueIk("ik"), asset("ast-Z"),
+                bind, null, null, null, null);
+        assertEquals("tok-bound", ((SuccessfulAssetCreation) s).result.tokenId);
+    }
+
+    @Test
+    void issueCreditsDestinationAndReturnsSuccessReceipt() {
+        String dst = "fin-" + System.nanoTime();
+        Asset a = asset("ast-iss-" + System.nanoTime());
+
+        ReceiptOperation op = service().issue(uniqueIk("ik"), a,
+                new FinIdAccount(dst), "100", null);
+
+        assertTrue(op instanceof SuccessReceiptStatus);
+        SuccessReceiptStatus s = (SuccessReceiptStatus) op;
+        assertEquals(OperationType.ISSUE, s.receipt.operationType);
+        assertEquals(dst, s.receipt.destination.finId);
+        assertEquals("100", storage.getBalance(dst, a.assetId).balance);
+    }
+
+    @Test
+    void transferLocalMovesBetweenAccounts() {
+        String src = "fin-src-" + System.nanoTime();
+        String dst = "fin-dst-" + System.nanoTime();
+        Asset a = asset("ast-tr-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        ReceiptOperation op = svc.transfer(uniqueIk("ik-tr"), "nonce",
+                new Source(src, new FinIdAccount(src)),
+                new Destination(dst, new FinIdAccount(dst)),
+                a, "40", sig(), null);
+
+        assertTrue(op instanceof SuccessReceiptStatus);
+        assertEquals("60", storage.getBalance(src, a.assetId).balance);
+        assertEquals("40", storage.getBalance(dst, a.assetId).balance);
+    }
+
+    @Test
+    void transferExternalSuccessLocksThenUnlockAndDebits() {
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-ext-" + System.nanoTime());
+        VanillaServiceImpl svcSeed = service();
+        svcSeed.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        TransferDelegate td = Mockito.mock(TransferDelegate.class);
+        Mockito.when(td.outboundTransfer(Mockito.anyString(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.eq("30"), Mockito.any())).thenReturn(DelegateResult.success("EXT-TX"));
+
+        // Destination with an external (LedgerAccount-shaped) account triggers the delegate path.
+        Destination external = new Destination("fin-ext", new io.ownera.ledger.adapter.service.model.LedgerAccount("wallet", "0xabc"));
+
+        ReceiptOperation op = service(null, td, null).transfer(uniqueIk("ik-ext"), "nonce",
+                new Source(src, new FinIdAccount(src)), external, a, "30", sig(), null);
+
+        assertTrue(op instanceof SuccessReceiptStatus);
+        assertEquals("70", storage.getBalance(src, a.assetId).balance);
+        assertEquals("0", storage.getBalance(src, a.assetId).held,
+                "external success path must unlockAndDebit, leaving no residual hold");
+    }
+
+    @Test
+    void transferExternalFailureUnlocksLocally() {
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-extf-" + System.nanoTime());
+        service().issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        TransferDelegate td = Mockito.mock(TransferDelegate.class);
+        Mockito.when(td.outboundTransfer(Mockito.anyString(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(DelegateResult.failure("network down"));
+
+        Destination external = new Destination("fin-ext", new io.ownera.ledger.adapter.service.model.LedgerAccount("wallet", "0xabc"));
+
+        ReceiptOperation op = service(null, td, null).transfer(uniqueIk("ik-extf"), "nonce",
+                new Source(src, new FinIdAccount(src)), external, a, "30", sig(), null);
+
+        assertTrue(op instanceof FailedReceiptStatus, "external failure must surface as Failed receipt");
+        // Balance restored to available; nothing held.
+        assertEquals("100", storage.getBalance(src, a.assetId).balance);
+        assertEquals("0", storage.getBalance(src, a.assetId).held);
+    }
+
+    @Test
+    void transferExternalWithoutDelegateReturnsFailed() {
+        Destination external = new Destination("fin-ext", new io.ownera.ledger.adapter.service.model.LedgerAccount("wallet", "0xabc"));
+        ReceiptOperation op = service().transfer(uniqueIk("ik"), "nonce",
+                new Source("fin-src", new FinIdAccount("fin-src")), external, asset("ast-nd"), "1", sig(), null);
+        assertTrue(op instanceof FailedReceiptStatus);
+    }
+
+    @Test
+    void redeemDebitsSource() {
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-rd-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        ReceiptOperation op = svc.redeem(uniqueIk("ik-rd"), "nonce",
+                new FinIdAccount(src), a, "25", null, sig(), null);
+        assertTrue(op instanceof SuccessReceiptStatus);
+        assertEquals("75", storage.getBalance(src, a.assetId).balance);
+    }
+
+    @Test
+    void getBalanceReturnsAvailable() {
+        String finId = "fin-" + System.nanoTime();
+        Asset a = asset("ast-bal-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik"), a, new FinIdAccount(finId), "100", null);
+        svc.hold(uniqueIk("ik2"), "n", new Source(finId, new FinIdAccount(finId)),
+                null, a, "30", sig(), "op-1", null);
+        assertEquals("70", svc.getBalance(a, finId));
+    }
+
+    @Test
+    void balanceReturnsBalanceHeldAndAvailable() {
+        String finId = "fin-" + System.nanoTime();
+        Asset a = asset("ast-bal2-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik"), a, new FinIdAccount(finId), "100", null);
+        svc.hold(uniqueIk("ik2"), "n", new Source(finId, new FinIdAccount(finId)),
+                null, a, "30", sig(), "op-1", null);
+
+        Balance b = svc.balance(a, finId);
+        assertEquals("100", b.current);
+        assertEquals("30", b.held);
+        assertEquals("70", b.available);
+    }
+
+    // ─── EscrowService ──────────────────────────────────────────────────────
+
+    @Test
+    void holdLocksFunds() {
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-hold-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        ReceiptOperation op = svc.hold(uniqueIk("ik-h"), "n",
+                new Source(src, new FinIdAccount(src)), null, a, "40", sig(), "op-1", null);
+        assertTrue(op instanceof SuccessReceiptStatus);
+        assertEquals("40", storage.getBalance(src, a.assetId).held);
+    }
+
+    @Test
+    void holdDelegateFailureUnlocksLocally() {
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-hold-f-" + System.nanoTime());
+        service().issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        EscrowDelegate ed = Mockito.mock(EscrowDelegate.class);
+        Mockito.when(ed.hold(Mockito.anyString(), Mockito.any(), Mockito.any(), Mockito.any(),
+                Mockito.anyString(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(DelegateResult.failure("ext-fail"));
+
+        ReceiptOperation op = service(null, null, ed).hold(uniqueIk("ik-h"), "n",
+                new Source(src, new FinIdAccount(src)), null, a, "40", sig(), "op-1", null);
+
+        assertTrue(op instanceof FailedReceiptStatus);
+        assertEquals("0", storage.getBalance(src, a.assetId).held);
+    }
+
+    @Test
+    void releaseUnlockAndMovesToDestination() {
+        String src = "fin-src-" + System.nanoTime();
+        String dst = "fin-dst-" + System.nanoTime();
+        Asset a = asset("ast-rel-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+        svc.hold(uniqueIk("ik-h"), "n", new Source(src, new FinIdAccount(src)),
+                null, a, "60", sig(), "op-1", null);
+
+        ReceiptOperation op = svc.release(uniqueIk("ik-r"),
+                new Source(src, new FinIdAccount(src)),
+                new Destination(dst, new FinIdAccount(dst)), a, "60", "op-1", null);
+
+        assertTrue(op instanceof SuccessReceiptStatus);
+        assertEquals("40", storage.getBalance(src, a.assetId).balance);
+        assertEquals("0", storage.getBalance(src, a.assetId).held);
+        assertEquals("60", storage.getBalance(dst, a.assetId).balance);
+    }
+
+    @Test
+    void rollbackReleasesHold() {
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-rb-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        svc.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "50", null);
+        svc.hold(uniqueIk("ik-h"), "n", new Source(src, new FinIdAccount(src)),
+                null, a, "20", sig(), "op-rb", null);
+
+        ReceiptOperation op = svc.rollback(uniqueIk("ik-rb"),
+                new Source(src, new FinIdAccount(src)), a, "20", "op-rb", null);
+
+        assertTrue(op instanceof SuccessReceiptStatus);
+        assertEquals("0", storage.getBalance(src, a.assetId).held);
+        assertEquals("50", storage.getBalance(src, a.assetId).balance);
+    }
+
+    // ─── CommonService ──────────────────────────────────────────────────────
+
+    @Test
+    void getReceiptReturnsBuiltReceipt() {
+        String dst = "fin-" + System.nanoTime();
+        Asset a = asset("ast-rcpt-" + System.nanoTime());
+        VanillaServiceImpl svc = service();
+        ReceiptOperation issued = svc.issue(uniqueIk("ik"), a, new FinIdAccount(dst), "10", null);
+        String txId = ((SuccessReceiptStatus) issued).receipt.id;
+
+        ReceiptOperation looked = svc.getReceipt(txId);
+        assertTrue(looked instanceof SuccessReceiptStatus);
+        assertEquals(txId, ((SuccessReceiptStatus) looked).receipt.id);
+        assertEquals(OperationType.ISSUE, ((SuccessReceiptStatus) looked).receipt.operationType);
+    }
+
+    @Test
+    void getReceiptNotFoundReturnsFailed() {
+        assertTrue(service().getReceipt("does-not-exist-" + System.nanoTime()) instanceof FailedReceiptStatus);
+    }
+
+    @Test
+    void operationStatusThrowsBecauseWorkflowProxyOwnsCidLookups() {
+        assertThrows(UnsupportedOperationException.class, () -> service().operationStatus("any"));
+    }
+
+    // ─── HealthService ──────────────────────────────────────────────────────
+
+    @Test
+    void livenessDoesNotThrowWhenDbReachable() {
+        assertDoesNotThrow(() -> service().liveness());
+        assertDoesNotThrow(() -> service().readiness());
+    }
+
+    // ─── InboundTransferHook ────────────────────────────────────────────────
+
+    @Test
+    void onInboundTransferCreditsDestination() {
+        String dst = "fin-in-" + System.nanoTime();
+        Asset a = asset("ast-in-" + System.nanoTime());
+        InboundTransferHook.InboundTransferContext ctx = new InboundTransferHook.InboundTransferContext(
+                "plan-1", "fin-src", a, dst, "50", 0,
+                InboundTransferHook.InstructionResult.receipt("ext-tx-1"));
+
+        service().onInboundTransfer(uniqueIk("ik"), ctx);
+
+        assertEquals("50", storage.getBalance(dst, a.assetId).balance);
+    }
+
+    @Test
+    void onInboundTransferSkipsCreditWhenDelegateThrowsVerificationError() {
+        String dst = "fin-in-" + System.nanoTime();
+        Asset a = asset("ast-in-skip-" + System.nanoTime());
+        TransferDelegate td = Mockito.mock(TransferDelegate.class);
+        Mockito.doThrow(new InboundTransferVerificationError("not on chain"))
+                .when(td).onInboundTransfer(Mockito.anyString(), Mockito.any(), Mockito.any(),
+                        Mockito.any(), Mockito.anyString(), Mockito.any());
+
+        InboundTransferHook.InboundTransferContext ctx = new InboundTransferHook.InboundTransferContext(
+                "plan-1", "fin-src", a, dst, "50", 0,
+                InboundTransferHook.InstructionResult.receipt("ext-tx-1"));
+
+        service(null, td, null).onInboundTransfer(uniqueIk("ik"), ctx);
+
+        // Verification failed → no credit.
+        assertEquals("0", storage.getBalance(dst, a.assetId).balance);
+    }
+}

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
@@ -310,6 +310,47 @@ class VanillaServiceImplTest {
     }
 
     @Test
+    void getReceiptForExternalTransferRoundTripsDelegateTxIdAndLedgerAccount() {
+        // Reviewer-flagged: external transfer POST returns a receipt with
+        // transactionDetails.transactionId = the delegate's external id and destination =
+        // LedgerAccount("wallet", ...). The follow-up getReceipt(localTxId) must reproduce both.
+        String src = "fin-src-" + System.nanoTime();
+        Asset a = asset("ast-ext-rt-" + System.nanoTime());
+        VanillaServiceImpl svcSeed = service();
+        svcSeed.issue(uniqueIk("ik-iss"), a, new FinIdAccount(src), "100", null);
+
+        TransferDelegate td = Mockito.mock(TransferDelegate.class);
+        Mockito.when(td.outboundTransfer(Mockito.anyString(), Mockito.any(), Mockito.any(),
+                Mockito.any(), Mockito.anyString(), Mockito.any()))
+                .thenReturn(DelegateResult.success("EXT-TX-ROUNDTRIP"));
+
+        Destination external = new Destination("fin-ext",
+                new io.ownera.ledger.adapter.service.model.LedgerAccount("wallet", "0xabc"));
+
+        VanillaServiceImpl svc = service(null, td, null);
+        ReceiptOperation op = svc.transfer(uniqueIk("ik-ext-rt"), "nonce",
+                new Source(src, new FinIdAccount(src)), external, a, "30", sig(), null);
+        assertTrue(op instanceof SuccessReceiptStatus);
+        io.ownera.ledger.adapter.service.model.Receipt post = ((SuccessReceiptStatus) op).receipt;
+        assertEquals("EXT-TX-ROUNDTRIP", post.transactionDetails.transactionId);
+        assertTrue(post.destination.account instanceof io.ownera.ledger.adapter.service.model.LedgerAccount,
+                "POST receipt destination must be LedgerAccount, got " + post.destination.account.getClass());
+
+        // Now look it up by the storage tx id — the receipt must carry the same fields.
+        ReceiptOperation looked = svc.getReceipt(post.id);
+        assertTrue(looked instanceof SuccessReceiptStatus);
+        io.ownera.ledger.adapter.service.model.Receipt got = ((SuccessReceiptStatus) looked).receipt;
+        assertEquals("EXT-TX-ROUNDTRIP", got.transactionDetails.transactionId,
+                "external tx id must round-trip through getReceipt");
+        assertTrue(got.destination.account instanceof io.ownera.ledger.adapter.service.model.LedgerAccount,
+                "destination must rehydrate as LedgerAccount, not be coerced back to FinIdAccount");
+        io.ownera.ledger.adapter.service.model.LedgerAccount la =
+                (io.ownera.ledger.adapter.service.model.LedgerAccount) got.destination.account;
+        assertEquals("wallet", la.type);
+        assertEquals("0xabc", la.address);
+    }
+
+    @Test
     void getReceiptNotFoundReturnsFailed() {
         assertTrue(service().getReceipt("does-not-exist-" + System.nanoTime()) instanceof FailedReceiptStatus);
     }

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaServiceImplTest.java
@@ -442,6 +442,88 @@ class VanillaServiceImplTest {
     }
 
     @Test
+    void onInboundTransferPersistsUpstreamTxIdAndExecutionContextForReceiptRoundTrip() {
+        // Reviewer-flagged: the credit row used to drop planId / instructionSequence and the
+        // upstream transactionId. Now we persist all three, and the TransferDelegate gets the
+        // execution context too, so a later getReceipt() reproduces the same provenance Node
+        // writes.
+        String dst = "fin-in-rt-" + System.nanoTime();
+        Asset a = asset("ast-in-rt-" + System.nanoTime());
+        TransferDelegate td = Mockito.mock(TransferDelegate.class);
+
+        InboundTransferHook.InboundTransferContext ctx = new InboundTransferHook.InboundTransferContext(
+                "plan-RT", "fin-src", a, dst, "75", 4,
+                InboundTransferHook.InstructionResult.receipt("UPSTREAM-TX-9"));
+
+        VanillaServiceImpl svc = service(null, td, null);
+        svc.onInboundTransfer(uniqueIk("ik"), ctx);
+
+        // Delegate must see the upstream tx id AND the execution context (planId/sequence),
+        // not the previous all-null hand-off.
+        Mockito.verify(td).onInboundTransfer(
+                Mockito.eq("UPSTREAM-TX-9"),
+                Mockito.any(),
+                Mockito.eq(a),
+                Mockito.any(),
+                Mockito.eq("75"),
+                Mockito.argThat(ec -> ec != null && "plan-RT".equals(ec.planId) && ec.sequence == 4));
+
+        assertEquals("75", storage.getBalance(dst, a.assetId).balance);
+
+        // Pull the credit row by transaction id (the credit returned a tx; we look it up via
+        // the receipt API) and check planId / sequence / upstream tx id survived.
+        io.ownera.ledger.adapter.vanilla.LedgerTransaction credit =
+                storage.findByOperationId("__missing__"); // sanity: lookups by operation_id won't find it (we didn't set one)
+        assertNull(credit);
+
+        // The most-recent credit row for this destination is what we just wrote.
+        // getReceipt by storage tx id should reproduce the upstream tx id and exCtx.
+        // Find the row id by scanning the most recent balance-bearing tx for this finId+asset:
+        // simplest: getReceipt accepts a tx id; we don't have it directly, so look it up via
+        // findByOperationId is not applicable. Instead, assert through the receipt builder
+        // by reading the row directly from the storage.
+        // (Service-level path: caller usually has the tx id from the credit return value;
+        // here we expose via the underlying storage to keep the assertion crisp.)
+        io.ownera.ledger.adapter.vanilla.LedgerTransaction row =
+                org.junit.jupiter.api.Assertions.assertDoesNotThrow(() -> latestCreditFor(dst, a.assetId));
+        assertEquals("UPSTREAM-TX-9", row.details.transactionId,
+                "upstream transactionId must round-trip into details.transaction_id");
+        assertNotNull(row.details.executionContext, "executionContext must be persisted");
+        assertEquals("plan-RT", row.details.executionContext.planId);
+        assertEquals(4, row.details.executionContext.sequence);
+
+        // Finally: the public receipt-lookup path reproduces the same fields.
+        ReceiptOperation looked = svc.getReceipt(row.id);
+        assertTrue(looked instanceof SuccessReceiptStatus);
+        io.ownera.ledger.adapter.service.model.Receipt got = ((SuccessReceiptStatus) looked).receipt;
+        assertEquals("UPSTREAM-TX-9", got.transactionDetails.transactionId,
+                "getReceipt() must return the upstream transactionId, not the local row id");
+        assertNotNull(got.tradeDetails.executionContext);
+        assertEquals("plan-RT", got.tradeDetails.executionContext.planId);
+        assertEquals(4, got.tradeDetails.executionContext.sequence);
+    }
+
+    /** Scan accounts for the destination + asset and return the inbound-transfer credit row.
+     *  Used by the round-trip test to grab the storage tx id without coupling to internals. */
+    private io.ownera.ledger.adapter.vanilla.LedgerTransaction latestCreditFor(String finId, String assetId) {
+        // The inbound-credit row is the only tx with destination = finId and action = 'credit'
+        // for this asset, so a direct query is fine here.
+        org.jooq.Record r = VanillaPostgresHolder.CTX.fetchOne(
+                "SELECT id, asset_id, asset_type, source, destination, " +
+                        "amount::TEXT AS amount, source_held::TEXT AS source_held, " +
+                        "destination_held::TEXT AS destination_held, " +
+                        "action, details, created_at " +
+                        "FROM " + VanillaPostgresHolder.SCHEMA + ".transactions " +
+                        "WHERE destination = ? AND asset_id = ? AND action = 'credit' " +
+                        "ORDER BY created_at DESC, id DESC LIMIT 1",
+                finId, assetId);
+        org.junit.jupiter.api.Assertions.assertNotNull(r);
+        // Build a LedgerTransaction via the storage's lookup so the details JSON is parsed via
+        // the same code path production uses.
+        return storage.getTransaction(r.get("id", String.class));
+    }
+
+    @Test
     void onInboundTransferSkipsCreditWhenDelegateThrowsVerificationError() {
         String dst = "fin-in-" + System.nanoTime();
         Asset a = asset("ast-in-skip-" + System.nanoTime());


### PR DESCRIPTION
## Summary

Adds the `vanilla-service` Maven module to the reactor — a reference per-investor ledger implementation, ported from the Node skeleton's [`vanilla-service`](https://github.com/owneraio/finp2p-nodejs-skeleton-adapter/tree/master/vanilla-service). Third in the PR sequence after #48 (PR 0, workflow correctness) and #49 (PR 1, async workflow proxy + crash recovery).

Distribution / omnibus is explicitly out of scope — that's PR 3.

## Decisions

- **Artifact**: `io.ownera:finp2p-java-vanilla-service`, depends on the skeleton. Adapters can pick it up independently.
- **Sample-adapter wiring**: none (Node's sample doesn't wire vanilla either; that's demo work, not strict parity).
- **AccountMappingService**: vanilla reuses the skeleton's `DefaultAccountMappingService` via constructor injection rather than forking a parallel store.

## What's in

**Migration** — `V3001__create_vanilla_ledger.sql`:
- `accounts (fin_id, asset_id, asset_type)` UNIQUE, with `balance NUMERIC` + `held NUMERIC` + CHECK constraints so `held ≤ balance` and `balance ≥ 0`.
- `transactions` with a UNIQUE index on `details->>'idempotency_key'` and a non-unique index on `operation_id` for lookups.

**Delegate interfaces** (adapter extension points):
- `AssetDelegate` — externalized asset creation.
- `TransferDelegate` — outbound transfer + `onInboundTransfer` verification.
- `EscrowDelegate` — hold / release / rollback against an external escrow.
- `DelegateResult` — `success(txId)` / `failure(error)`.
- `InboundTransferVerificationError` — signals "skip the local credit".

**`LedgerStorage`**:
- Atomic CTE-based `transfer(...)` ported from the Node vanilla adapter. Per-asset `pg_advisory_xact_lock` serializes operations on the same asset; same-thread idempotency-key short-circuit; CHECK-constraint violations translated into `BusinessException(1, "Insufficient balance for …")`.
- Sugar over the CTE: `credit / debit / lock / unlock / move / unlockAndMove / unlockAndDebit`.
- Lookups: `getBalance`, `getTransaction`, `findByOperationId`.
- Schema name validated against `[a-zA-Z_][a-zA-Z0-9_]*` before splicing into raw SQL.

**`VanillaServiceImpl`**:
- One facade implementing `TokenService + EscrowService + CommonService + HealthService + AccountMappingService + InboundTransferHook` (matches the Node facade; `PaymentService` is intentionally omitted, same as Node).
- Each token/escrow operation wraps the storage call with delegate-driven hooks in the same order as Node:
  - external transfer: `lock` → `outboundTransfer` → (success) `unlockAndDebit` / (failure) `unlock`.
  - `hold`: `storage.lock` → `delegate.hold`; delegate failure → `storage.unlock`.
  - `release`: `delegate.release` → `storage.unlockAndMove` (failure keeps funds held).
  - `rollback`: `delegate.rollback` → `storage.unlock` (failure keeps funds held).
- `onInboundTransfer` skips the local credit when `InboundTransferVerificationError` is thrown.

## Tests (35 new; 97 across the reactor)

- `LedgerStorageTest` (14) — round-trip per storage operation, idempotency, CHECK-constraint enforcement, schema-name validation, `getTransaction` / `findByOperationId` round-trip.
- `VanillaServiceImplTest` (21) — every `TokenService / EscrowService / CommonService / HealthService / InboundTransferHook` method exercised against a real Postgres via Testcontainers, with Mockito-driven delegate behavior for the external-transfer success / failure / no-delegate branches.

## Test plan

- [ ] CI: build + tests across all three modules
- [ ] CodeQL: java-kotlin analyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)