### PR TITLE
PR 3: omnibus / distribution service (per-asset reconciliation)

### DIFF
--- a/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
+++ b/sample-adapter/src/test/java/io/ownera/ledger/adapter/postgres/WorkflowServiceProxyTest.java
@@ -350,6 +350,22 @@ public class WorkflowServiceProxyTest {
     }
 
     @Test
+    void workflowArgsCodecKeepsUppercaseAssetTypeForHashStability() {
+        // Cross-PR regression: PR 3 added a Node-style lowercase wire format for AssetType on
+        // the /distribution/* HTTP surface. That fix must stay localized — the workflow proxy
+        // hashes its serialized args into inputs_hash, so flipping the global wire shape would
+        // make pre-upgrade rows un-findable (idempotent replay starts re-executing). The codec
+        // must still serialize AssetType as the uppercase enum name.
+        io.ownera.ledger.adapter.service.workflow.WorkflowArgsCodec codec =
+                new io.ownera.ledger.adapter.service.workflow.WorkflowArgsCodec();
+        String json = codec.encode(new Object[]{asset("ast-stable")});
+        assertTrue(json.contains("\"FINP2P\""),
+                "AssetType must serialize uppercase in workflow args (got " + json + ")");
+        assertFalse(json.contains("\"finp2p\""),
+                "AssetType must NOT serialize lowercase in workflow args (would break inputs_hash)");
+    }
+
+    @Test
     void nonProxiedMethodPassesThrough() {
         StubTokenService stub = new StubTokenService();
         TokenService proxied = wrap(stub, null);

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/AssetType.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/AssetType.java
@@ -1,7 +1,37 @@
 package io.ownera.ledger.adapter.service.model;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum AssetType {
     FINP2P,
     FIAT,
-    CRYPTOCURRENCY
+    CRYPTOCURRENCY;
+
+    /**
+     * Wire form is the lowercase enum name — matches the Node skeleton's
+     * {@code AssetType = 'finp2p' | 'fiat' | 'cryptocurrency'} string-literal union so requests
+     * and responses round-trip cleanly across both implementations.
+     */
+    @JsonValue
+    public String toWire() {
+        return name().toLowerCase();
+    }
+
+    /**
+     * Lenient parse: accepts both {@code "finp2p"} (Node-style) and {@code "FINP2P"} (the
+     * legacy JSON shape, before this annotation was added). Mixed casing also works. Existing
+     * persisted JSONB rows (e.g. workflow proxy inputs from earlier builds) keep deserializing.
+     */
+    @JsonCreator
+    public static AssetType fromWire(String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("AssetType wire value cannot be null");
+        }
+        try {
+            return AssetType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown AssetType: " + value, e);
+        }
+    }
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/AssetType.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/model/AssetType.java
@@ -1,37 +1,7 @@
 package io.ownera.ledger.adapter.service.model;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-
 public enum AssetType {
     FINP2P,
     FIAT,
-    CRYPTOCURRENCY;
-
-    /**
-     * Wire form is the lowercase enum name — matches the Node skeleton's
-     * {@code AssetType = 'finp2p' | 'fiat' | 'cryptocurrency'} string-literal union so requests
-     * and responses round-trip cleanly across both implementations.
-     */
-    @JsonValue
-    public String toWire() {
-        return name().toLowerCase();
-    }
-
-    /**
-     * Lenient parse: accepts both {@code "finp2p"} (Node-style) and {@code "FINP2P"} (the
-     * legacy JSON shape, before this annotation was added). Mixed casing also works. Existing
-     * persisted JSONB rows (e.g. workflow proxy inputs from earlier builds) keep deserializing.
-     */
-    @JsonCreator
-    public static AssetType fromWire(String value) {
-        if (value == null) {
-            throw new IllegalArgumentException("AssetType wire value cannot be null");
-        }
-        try {
-            return AssetType.valueOf(value.toUpperCase());
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("Unknown AssetType: " + value, e);
-        }
-    }
+    CRYPTOCURRENCY
 }

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/AssetTypeWire.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/AssetTypeWire.java
@@ -1,0 +1,62 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import io.ownera.ledger.adapter.service.model.AssetType;
+
+import javax.annotation.Nullable;
+import java.io.IOException;
+
+/**
+ * Wire-format converters for {@link AssetType} on the {@code /distribution/*} HTTP surface.
+ *
+ * <p>Node's distribution contract uses lowercase string literals ({@code "finp2p" | "fiat" |
+ * "cryptocurrency"}). Java's default Jackson enum binding would emit and require the uppercase
+ * {@code name()} ({@code "FINP2P"}). To bridge that — without changing the global wire shape
+ * of {@link AssetType} (the workflow proxy hashes its serialized form into
+ * {@code inputs_hash}; flipping that across an upgrade would silently break idempotent
+ * replay) — the distribution DTOs annotate their {@code assetType} field with
+ * {@link Serializer} / {@link Deserializer}.
+ *
+ * <p>Deserialization is lenient: accepts both casings so an adapter that has already been
+ * sending the Node-style lowercase form keeps working, and clients/tests still pinning to
+ * uppercase also keep working. Serialization is always lowercase.
+ */
+public final class AssetTypeWire {
+
+    private AssetTypeWire() {}
+
+    public static AssetType parse(@Nullable String value) {
+        if (value == null) {
+            throw new IllegalArgumentException("assetType cannot be null");
+        }
+        try {
+            return AssetType.valueOf(value.toUpperCase());
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("Unknown assetType: " + value, e);
+        }
+    }
+
+    public static String toWire(AssetType type) {
+        return type.name().toLowerCase();
+    }
+
+    public static final class Serializer extends JsonSerializer<AssetType> {
+        @Override
+        public void serialize(AssetType value, JsonGenerator gen, SerializerProvider provider)
+                throws IOException {
+            gen.writeString(toWire(value));
+        }
+    }
+
+    public static final class Deserializer extends JsonDeserializer<AssetType> {
+        @Override
+        public AssetType deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+            return parse(p.getValueAsString());
+        }
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributedAccount.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributedAccount.java
@@ -1,17 +1,28 @@
 package io.ownera.ledger.adapter.vanilla;
 
+import java.math.BigDecimal;
+
 /**
  * Per-investor account snapshot returned by {@link LedgerStorage#listDistributedAccounts}.
  * Used by the distribution flush to iterate every account that currently holds value for
  * a given asset (omnibus excluded).
+ *
+ * <p>{@code balance} is the raw row total; {@code held} is the locked portion; {@code available}
+ * = {@code balance − held} is the spendable amount the flush can actually move. The flush
+ * uses {@code available} so an account with an outstanding escrow lock doesn't trip the
+ * {@code CHECK (held <= balance)} constraint mid-loop.
  */
 public final class DistributedAccount {
 
     public final String finId;
     public final String balance;
+    public final String held;
+    public final String available;
 
-    public DistributedAccount(String finId, String balance) {
+    public DistributedAccount(String finId, String balance, String held) {
         this.finId = finId;
         this.balance = balance;
+        this.held = held;
+        this.available = new BigDecimal(balance).subtract(new BigDecimal(held)).toPlainString();
     }
 }

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributedAccount.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributedAccount.java
@@ -1,0 +1,17 @@
+package io.ownera.ledger.adapter.vanilla;
+
+/**
+ * Per-investor account snapshot returned by {@link LedgerStorage#listDistributedAccounts}.
+ * Used by the distribution flush to iterate every account that currently holds value for
+ * a given asset (omnibus excluded).
+ */
+public final class DistributedAccount {
+
+    public final String finId;
+    public final String balance;
+
+    public DistributedAccount(String finId, String balance) {
+        this.finId = finId;
+        this.balance = balance;
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionController.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionController.java
@@ -1,0 +1,146 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.ownera.ledger.adapter.service.BusinessException;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.annotation.Nullable;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * HTTP surface for {@link DistributionService}, mirroring Node's
+ * {@code registerDistributionRoutes} ({@code vanilla-service/src/routes.ts}).
+ *
+ * <ul>
+ *   <li>{@code POST /distribution/sync}      — reconcile omnibus DB with on-chain balance.</li>
+ *   <li>{@code GET  /distribution/status}    — read-only omnibus vs distributed.</li>
+ *   <li>{@code POST /distribution/distribute} — allocate omnibus value to investor.</li>
+ *   <li>{@code POST /distribution/reclaim}    — return investor value to undistributed pool.</li>
+ *   <li>{@code POST /distribution/flush}      — reclaim every per-investor account to omnibus.</li>
+ * </ul>
+ *
+ * <p>Validation failures return {@code 400}; business errors (e.g. on-chain balance below
+ * distributed total, overdraft on reclaim) return {@code 409}; unexpected failures bubble up
+ * as {@code 500} through Spring's default handler.
+ *
+ * <p>This bean is opt-in: it only activates when a {@link DistributionService} bean is
+ * present in the application context.
+ */
+@RestController
+@RequestMapping("/distribution")
+public class DistributionController {
+
+    private final DistributionService distributionService;
+
+    public DistributionController(DistributionService distributionService) {
+        this.distributionService = distributionService;
+    }
+
+    @PostMapping("/sync")
+    public ResponseEntity<DistributionStatus> sync(@RequestBody AssetRequest body) {
+        requireNonBlank(body.assetId, "assetId");
+        return ResponseEntity.ok(distributionService.syncOmnibus(body.assetId, body.assetTypeOrDefault()));
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<DistributionStatus> status(
+            @RequestParam("assetId") String assetId,
+            @RequestParam(value = "assetType", required = false) AssetType assetType) {
+        requireNonBlank(assetId, "assetId");
+        return ResponseEntity.ok(distributionService.getDistributionStatus(
+                assetId, assetType != null ? assetType : AssetType.FINP2P));
+    }
+
+    @PostMapping("/distribute")
+    public ResponseEntity<Map<String, String>> distribute(@RequestBody InvestorAmountRequest body) {
+        requireNonBlank(body.finId, "finId");
+        requireNonBlank(body.assetId, "assetId");
+        requireNonBlank(body.amount, "amount");
+        distributionService.distribute(body.finId, body.assetId, body.assetTypeOrDefault(), body.amount);
+        return ResponseEntity.ok(Collections.singletonMap("status", "ok"));
+    }
+
+    @PostMapping("/reclaim")
+    public ResponseEntity<Map<String, String>> reclaim(@RequestBody InvestorAmountRequest body) {
+        requireNonBlank(body.finId, "finId");
+        requireNonBlank(body.assetId, "assetId");
+        requireNonBlank(body.amount, "amount");
+        distributionService.reclaim(body.finId, body.assetId, body.assetTypeOrDefault(), body.amount);
+        return ResponseEntity.ok(Collections.singletonMap("status", "ok"));
+    }
+
+    @PostMapping("/flush")
+    public ResponseEntity<DistributionStatus> flush(@RequestBody AssetRequest body) {
+        requireNonBlank(body.assetId, "assetId");
+        return ResponseEntity.ok(distributionService.flushDistributions(body.assetId, body.assetTypeOrDefault()));
+    }
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Map<String, String>> onBusiness(BusinessException e) {
+        return ResponseEntity.status(HttpStatus.CONFLICT)
+                .body(Collections.singletonMap("error", e.getMessage()));
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> onBadRequest(IllegalArgumentException e) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(Collections.singletonMap("error", e.getMessage()));
+    }
+
+    private static void requireNonBlank(@Nullable String value, String name) {
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException(name + " is required");
+        }
+    }
+
+    // ─── Request bodies ─────────────────────────────────────────────────────
+
+    public static final class AssetRequest {
+        public final String assetId;
+        public final @Nullable AssetType assetType;
+
+        @JsonCreator
+        public AssetRequest(@JsonProperty("assetId") String assetId,
+                            @JsonProperty("assetType") @Nullable AssetType assetType) {
+            this.assetId = assetId;
+            this.assetType = assetType;
+        }
+
+        AssetType assetTypeOrDefault() {
+            return assetType != null ? assetType : AssetType.FINP2P;
+        }
+    }
+
+    public static final class InvestorAmountRequest {
+        public final String finId;
+        public final String assetId;
+        public final @Nullable AssetType assetType;
+        public final String amount;
+
+        @JsonCreator
+        public InvestorAmountRequest(@JsonProperty("finId") String finId,
+                                     @JsonProperty("assetId") String assetId,
+                                     @JsonProperty("assetType") @Nullable AssetType assetType,
+                                     @JsonProperty("amount") String amount) {
+            this.finId = finId;
+            this.assetId = assetId;
+            this.assetType = assetType;
+            this.amount = amount;
+        }
+
+        AssetType assetTypeOrDefault() {
+            return assetType != null ? assetType : AssetType.FINP2P;
+        }
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionController.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionController.java
@@ -2,6 +2,7 @@ package io.ownera.ledger.adapter.vanilla;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.ownera.ledger.adapter.service.BusinessException;
 import io.ownera.ledger.adapter.service.model.AssetType;
 import org.springframework.http.HttpStatus;
@@ -58,10 +59,11 @@ public class DistributionController {
             @RequestParam("assetId") String assetId,
             @RequestParam(value = "assetType", required = false) String assetType) {
         requireNonBlank(assetId, "assetId");
-        // Bind assetType as String + parse via AssetType.fromWire so we accept the Node-style
-        // lowercase form ("finp2p"). Spring's default String→enum converter is case-sensitive
-        // and would 400 on lowercase.
-        AssetType resolved = assetType != null ? AssetType.fromWire(assetType) : AssetType.FINP2P;
+        // Bind assetType as String + parse locally so the lowercase wire form is accepted on
+        // the distribution surface only. Spring's default String→enum converter is
+        // case-sensitive and would 400 on "finp2p"; AssetType itself stays case-strict so the
+        // workflow proxy's inputs_hash isn't disturbed.
+        AssetType resolved = assetType != null ? AssetTypeWire.parse(assetType) : AssetType.FINP2P;
         return ResponseEntity.ok(distributionService.getDistributionStatus(assetId, resolved));
     }
 
@@ -115,7 +117,9 @@ public class DistributionController {
 
         @JsonCreator
         public AssetRequest(@JsonProperty("assetId") String assetId,
-                            @JsonProperty("assetType") @Nullable AssetType assetType) {
+                            @JsonProperty("assetType")
+                            @JsonDeserialize(using = AssetTypeWire.Deserializer.class)
+                            @Nullable AssetType assetType) {
             this.assetId = assetId;
             this.assetType = assetType;
         }
@@ -134,7 +138,9 @@ public class DistributionController {
         @JsonCreator
         public InvestorAmountRequest(@JsonProperty("finId") String finId,
                                      @JsonProperty("assetId") String assetId,
-                                     @JsonProperty("assetType") @Nullable AssetType assetType,
+                                     @JsonProperty("assetType")
+                                     @JsonDeserialize(using = AssetTypeWire.Deserializer.class)
+                                     @Nullable AssetType assetType,
                                      @JsonProperty("amount") String amount) {
             this.finId = finId;
             this.assetId = assetId;

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionController.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionController.java
@@ -56,10 +56,13 @@ public class DistributionController {
     @GetMapping("/status")
     public ResponseEntity<DistributionStatus> status(
             @RequestParam("assetId") String assetId,
-            @RequestParam(value = "assetType", required = false) AssetType assetType) {
+            @RequestParam(value = "assetType", required = false) String assetType) {
         requireNonBlank(assetId, "assetId");
-        return ResponseEntity.ok(distributionService.getDistributionStatus(
-                assetId, assetType != null ? assetType : AssetType.FINP2P));
+        // Bind assetType as String + parse via AssetType.fromWire so we accept the Node-style
+        // lowercase form ("finp2p"). Spring's default String→enum converter is case-sensitive
+        // and would 400 on lowercase.
+        AssetType resolved = assetType != null ? AssetType.fromWire(assetType) : AssetType.FINP2P;
+        return ResponseEntity.ok(distributionService.getDistributionStatus(assetId, resolved));
     }
 
     @PostMapping("/distribute")

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionRoutesConfig.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionRoutesConfig.java
@@ -1,0 +1,32 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Opt-in entry point for the distribution HTTP routes.
+ *
+ * <p>Mirrors Node's {@code registerDistributionRoutes(app, distributionService)} callback
+ * ({@code vanilla-service/src/routes.ts}). In Spring the equivalent of "register these
+ * routes on my app" is "import this config class": adapters wire the routes by adding
+ *
+ * <pre>{@code
+ *   @Import(DistributionRoutesConfig.class)
+ * }</pre>
+ *
+ * to their own Spring configuration. The adapter is responsible for supplying a
+ * {@link DistributionService} bean — typically a {@link VanillaDistributionService}
+ * constructed with a {@link LedgerStorage} and an {@link OmnibusDelegate} the adapter
+ * implements.
+ *
+ * <p>Vanilla-service stays a library: the controller class is present in the JAR but
+ * inert unless the adapter explicitly imports this config.
+ */
+@Configuration
+public class DistributionRoutesConfig {
+
+    @Bean
+    public DistributionController distributionController(DistributionService distributionService) {
+        return new DistributionController(distributionService);
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionService.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionService.java
@@ -1,0 +1,40 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.model.AssetType;
+
+/**
+ * Omnibus / distribution operations layered on top of the vanilla per-investor ledger.
+ *
+ * <p>The omnibus account holds the asset's on-chain balance; per-investor accounts represent
+ * sub-allocations of that pool. {@link #distribute} and {@link #reclaim} move value between
+ * the omnibus row and an investor row; {@link #syncOmnibus} reconciles the local omnibus row
+ * against the actual on-chain balance read via {@link OmnibusDelegate}.
+ *
+ * <p>Mirrors Node's {@code DistributionService} interface in
+ * {@code vanilla-service/src/interfaces.ts}.
+ */
+public interface DistributionService {
+
+    /**
+     * Reads the on-chain omnibus balance via the {@link OmnibusDelegate} and reconciles the
+     * local omnibus row. Throws {@link io.ownera.ledger.adapter.service.BusinessException}
+     * when the on-chain balance is less than the already-distributed total (the local omnibus
+     * row would have to go negative).
+     */
+    DistributionStatus syncOmnibus(String assetId, AssetType assetType);
+
+    /** Read-only breakdown of omnibus vs distributed value. */
+    DistributionStatus getDistributionStatus(String assetId, AssetType assetType);
+
+    /** Allocate omnibus value to an investor account. */
+    void distribute(String finId, String assetId, AssetType assetType, String amount);
+
+    /** Return investor value to the undistributed pool. */
+    void reclaim(String finId, String assetId, AssetType assetType, String amount);
+
+    /**
+     * Reclaim every per-investor account back to omnibus for the given asset. Each reclaim is
+     * a separate ledger move (and a separate audit row); the post-flush status is returned.
+     */
+    DistributionStatus flushDistributions(String assetId, AssetType assetType);
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionStatus.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionStatus.java
@@ -1,0 +1,44 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.ownera.ledger.adapter.service.model.AssetType;
+
+/**
+ * Wire-shape returned by {@link DistributionService} (and the {@code /distribution/*} routes).
+ *
+ * <p>Mirrors Node's {@code DistributionStatus} type in
+ * {@code vanilla-service/src/interfaces.ts}: the omnibus top-line plus the
+ * already-distributed and still-available breakdown.
+ */
+public final class DistributionStatus {
+
+    @JsonProperty("assetId")
+    public final String assetId;
+
+    @JsonProperty("assetType")
+    public final AssetType assetType;
+
+    @JsonProperty("omnibusBalance")
+    public final String omnibusBalance;
+
+    @JsonProperty("distributedBalance")
+    public final String distributedBalance;
+
+    @JsonProperty("availableBalance")
+    public final String availableBalance;
+
+    @JsonCreator
+    public DistributionStatus(
+            @JsonProperty("assetId") String assetId,
+            @JsonProperty("assetType") AssetType assetType,
+            @JsonProperty("omnibusBalance") String omnibusBalance,
+            @JsonProperty("distributedBalance") String distributedBalance,
+            @JsonProperty("availableBalance") String availableBalance) {
+        this.assetId = assetId;
+        this.assetType = assetType;
+        this.omnibusBalance = omnibusBalance;
+        this.distributedBalance = distributedBalance;
+        this.availableBalance = availableBalance;
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionStatus.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionStatus.java
@@ -2,6 +2,8 @@ package io.ownera.ledger.adapter.vanilla;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import io.ownera.ledger.adapter.service.model.AssetType;
 
 /**
@@ -17,6 +19,8 @@ public final class DistributionStatus {
     public final String assetId;
 
     @JsonProperty("assetType")
+    @JsonSerialize(using = AssetTypeWire.Serializer.class)
+    @JsonDeserialize(using = AssetTypeWire.Deserializer.class)
     public final AssetType assetType;
 
     @JsonProperty("omnibusBalance")

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionTotals.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/DistributionTotals.java
@@ -1,0 +1,26 @@
+package io.ownera.ledger.adapter.vanilla;
+
+/**
+ * Storage-layer breakdown of an asset's distribution state.
+ *
+ * <ul>
+ *   <li>{@code omnibusBalance} — top-line balance (omnibus row + per-investor balances).</li>
+ *   <li>{@code distributed} — sum of per-investor account balances.</li>
+ *   <li>{@code available} — balance still on the omnibus row (not yet distributed).</li>
+ * </ul>
+ *
+ * <p>Numeric strings rather than {@code BigDecimal} so the value round-trips cleanly with the
+ * Postgres {@code NUMERIC} column and the API layer (which deals in string-encoded numerics).
+ */
+public final class DistributionTotals {
+
+    public final String omnibusBalance;
+    public final String distributed;
+    public final String available;
+
+    public DistributionTotals(String omnibusBalance, String distributed, String available) {
+        this.omnibusBalance = omnibusBalance;
+        this.distributed = distributed;
+        this.available = available;
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
@@ -42,6 +42,9 @@ public class LedgerStorage {
     private final String getTransactionSql;
     private final String findByOperationIdSql;
     private final String transferSql;
+    private final String listDistributedAccountsSql;
+    private final String getDistributionStatusSql;
+    private final String syncOmnibusBalanceSql;
 
     public LedgerStorage(DSLContext dsl, String schemaName) {
         if (!SCHEMA_NAME_RE.matcher(schemaName).matches()) {
@@ -51,11 +54,14 @@ public class LedgerStorage {
         this.schema = schemaName;
         String accountsTable = schemaName + ".accounts";
         String transactionsTable = schemaName + ".transactions";
-        this.ensureAccountSql     = String.format(ENSURE_ACCOUNT_TEMPLATE,      accountsTable);
-        this.getBalanceSql        = String.format(GET_BALANCE_TEMPLATE,         accountsTable);
-        this.getTransactionSql    = String.format(GET_TRANSACTION_TEMPLATE,     transactionsTable);
-        this.findByOperationIdSql = String.format(FIND_BY_OPERATION_ID_TEMPLATE, transactionsTable);
-        this.transferSql          = String.format(TRANSFER_SQL_TEMPLATE,        transactionsTable, accountsTable);
+        this.ensureAccountSql           = String.format(ENSURE_ACCOUNT_TEMPLATE,            accountsTable);
+        this.getBalanceSql              = String.format(GET_BALANCE_TEMPLATE,               accountsTable);
+        this.getTransactionSql          = String.format(GET_TRANSACTION_TEMPLATE,           transactionsTable);
+        this.findByOperationIdSql       = String.format(FIND_BY_OPERATION_ID_TEMPLATE,      transactionsTable);
+        this.transferSql                = String.format(TRANSFER_SQL_TEMPLATE,              transactionsTable, accountsTable);
+        this.listDistributedAccountsSql = String.format(LIST_DISTRIBUTED_ACCOUNTS_TEMPLATE, accountsTable);
+        this.getDistributionStatusSql   = String.format(GET_DISTRIBUTION_STATUS_TEMPLATE,   accountsTable);
+        this.syncOmnibusBalanceSql      = String.format(SYNC_OMNIBUS_BALANCE_TEMPLATE,      accountsTable);
     }
 
     // SQL templates. Table names are spliced once at construction via String.format — they're
@@ -89,6 +95,38 @@ public class LedgerStorage {
                     "WHERE details->>'operation_id' = ? " +
                     "ORDER BY created_at DESC, id DESC " +
                     "LIMIT 1";
+
+    private static final String LIST_DISTRIBUTED_ACCOUNTS_TEMPLATE =
+            "SELECT fin_id, balance::TEXT AS balance " +
+                    "FROM %s " +
+                    "WHERE asset_id = ? AND asset_type = ? AND fin_id != ? AND balance > 0 " +
+                    "ORDER BY fin_id";
+
+    private static final String GET_DISTRIBUTION_STATUS_TEMPLATE =
+            "SELECT COALESCE(o.balance, 0)::TEXT                          AS available, " +
+                    "       COALESCE(d.total, 0)::TEXT                          AS distributed, " +
+                    "       (COALESCE(o.balance, 0) + COALESCE(d.total, 0))::TEXT AS omnibus_balance " +
+                    "FROM " +
+                    "  (SELECT balance FROM %1$s " +
+                    "   WHERE fin_id = ? AND asset_id = ? AND asset_type = ?) o " +
+                    "FULL JOIN " +
+                    "  (SELECT SUM(balance) AS total FROM %1$s " +
+                    "   WHERE asset_id = ? AND asset_type = ? AND fin_id != ?) d ON TRUE";
+
+    private static final String SYNC_OMNIBUS_BALANCE_TEMPLATE =
+            "WITH lock_asset AS (" +
+                    "  SELECT pg_advisory_xact_lock(hashtext(?), hashtext(?))" +
+                    "), " +
+                    "distributed AS (" +
+                    "  SELECT COALESCE(SUM(a.balance), 0) AS total " +
+                    "  FROM %1$s a, lock_asset " +
+                    "  WHERE a.asset_id = ? AND a.asset_type = ? AND a.fin_id != ?" +
+                    ") " +
+                    "UPDATE %1$s a " +
+                    "SET balance = CAST(? AS NUMERIC) - d.total, updated_at = NOW() " +
+                    "FROM distributed d " +
+                    "WHERE a.fin_id = ? AND a.asset_id = ? AND a.asset_type = ? " +
+                    "RETURNING d.total::TEXT AS distributed, a.balance::TEXT AS available";
 
     /**
      * One-shot CTE template: {@code %1$s} = transactions table, {@code %2$s} = accounts table.
@@ -283,6 +321,72 @@ public class LedgerStorage {
     public LedgerTransaction findByOperationId(String operationId) {
         Record r = dsl.fetchOne(findByOperationIdSql, operationId);
         return r != null ? toLedgerTransaction(r) : null;
+    }
+
+    // ─── Distribution queries ───────────────────────────────────────────────
+
+    /**
+     * Returns all per-investor accounts with positive balances for an asset, excluding the
+     * omnibus account itself. Used to enumerate what would be touched by a bulk flush back into
+     * omnibus.
+     */
+    public java.util.List<DistributedAccount> listDistributedAccounts(
+            String omnibusFinId, String assetId, String assetType) {
+        return dsl.fetch(listDistributedAccountsSql, assetId, assetType, omnibusFinId)
+                .stream()
+                .map(r -> new DistributedAccount(
+                        r.get("fin_id", String.class),
+                        r.get("balance", String.class)))
+                .collect(java.util.stream.Collectors.toList());
+    }
+
+    /**
+     * Returns omnibus + distributed breakdown for an asset, with all arithmetic done in SQL.
+     * {@code omnibusBalance} is the conceptual top-line (omnibus row + sum of investor rows),
+     * {@code distributed} is the sum of investor balances, {@code available} is what's left on
+     * the omnibus row.
+     */
+    public DistributionTotals getDistributionStatus(
+            String omnibusFinId, String assetId, String assetType) {
+        Record r = dsl.fetchOne(getDistributionStatusSql,
+                omnibusFinId, assetId, assetType,
+                assetId, assetType, omnibusFinId);
+        if (r == null) {
+            return new DistributionTotals("0", "0", "0");
+        }
+        return new DistributionTotals(
+                r.get("omnibus_balance", String.class),
+                r.get("distributed", String.class),
+                r.get("available", String.class));
+    }
+
+    /**
+     * Atomically reconcile the omnibus DB row with the supplied on-chain balance.
+     *
+     * <p>Single UPDATE takes a per-asset advisory lock (same key as
+     * {@link #transferSql}, so sync and balance mutations serialize) and computes:
+     * {@code target = onChainBalance - SUM(other investor balances)}.
+     *
+     * <p>If {@code onChainBalance} is less than the already-distributed total, the UPDATE
+     * pushes {@code balance} below zero and the {@code CHECK (balance >= 0)} constraint
+     * aborts the statement. The caller (service layer) is expected to translate that into
+     * a meaningful business error.
+     */
+    public DistributionTotals syncOmnibusBalance(
+            String omnibusFinId, String assetId, String onChainBalance, String assetType) {
+        Record r = dsl.fetchOne(syncOmnibusBalanceSql,
+                assetId, assetType,           // lock_asset hashtext args
+                assetId, assetType, omnibusFinId, // distributed CTE
+                onChainBalance,                // SET balance = ?
+                omnibusFinId, assetId, assetType); // WHERE
+        if (r == null) {
+            throw new io.ownera.ledger.adapter.service.BusinessException(1,
+                    "syncOmnibusBalance: omnibus account row not found for assetId=" + assetId);
+        }
+        return new DistributionTotals(
+                onChainBalance,
+                r.get("distributed", String.class),
+                r.get("available", String.class));
     }
 
     // ─── Atomic CTE transfer ────────────────────────────────────────────────

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/LedgerStorage.java
@@ -97,7 +97,7 @@ public class LedgerStorage {
                     "LIMIT 1";
 
     private static final String LIST_DISTRIBUTED_ACCOUNTS_TEMPLATE =
-            "SELECT fin_id, balance::TEXT AS balance " +
+            "SELECT fin_id, balance::TEXT AS balance, held::TEXT AS held " +
                     "FROM %s " +
                     "WHERE asset_id = ? AND asset_type = ? AND fin_id != ? AND balance > 0 " +
                     "ORDER BY fin_id";
@@ -336,7 +336,8 @@ public class LedgerStorage {
                 .stream()
                 .map(r -> new DistributedAccount(
                         r.get("fin_id", String.class),
-                        r.get("balance", String.class)))
+                        r.get("balance", String.class),
+                        r.get("held", String.class)))
                 .collect(java.util.stream.Collectors.toList());
     }
 

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/OmnibusDelegate.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/OmnibusDelegate.java
@@ -1,0 +1,22 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.model.AssetType;
+
+/**
+ * Reads the on-chain balance of the omnibus wallet for a given asset.
+ *
+ * <p>{@link DistributionService} requires a delegate — the on-chain balance is the source of
+ * truth that the local omnibus row is reconciled against, so the vanilla service cannot
+ * function as a distribution-tracking adapter without it.
+ *
+ * <p>Mirrors Node's {@code OmnibusDelegate} interface in
+ * {@code vanilla-service/src/interfaces.ts}.
+ */
+public interface OmnibusDelegate {
+
+    /**
+     * @return the on-chain balance of the omnibus account for {@code (assetId, assetType)},
+     *         encoded as a numeric string (same format as the storage layer uses).
+     */
+    String getOmnibusBalance(String assetId, AssetType assetType);
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionService.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionService.java
@@ -1,0 +1,113 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.BusinessException;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.List;
+
+/**
+ * {@link DistributionService} implementation backed by {@link LedgerStorage} and a required
+ * {@link OmnibusDelegate}.
+ *
+ * <p>Ported from Node's vanilla service's distribution methods
+ * ({@code vanilla-service/src/service.ts}). The omnibus account is identified by a well-known
+ * synthetic finId ({@code __omnibus__}) so distribution operations never collide with real
+ * investor finIds.
+ */
+public class VanillaDistributionService implements DistributionService {
+
+    private static final Logger logger = LoggerFactory.getLogger(VanillaDistributionService.class);
+    private static final SecureRandom RNG = new SecureRandom();
+
+    /** Well-known finId prefix used in the {@code accounts} table for omnibus rows. */
+    public static final String OMNIBUS_FIN_ID = "__omnibus__";
+
+    private final LedgerStorage storage;
+    private final OmnibusDelegate omnibusDelegate;
+
+    public VanillaDistributionService(LedgerStorage storage, OmnibusDelegate omnibusDelegate) {
+        if (omnibusDelegate == null) {
+            // DistributionService cannot function without an on-chain source of truth — fail
+            // fast at construction rather than at the first syncOmnibus call.
+            throw new IllegalArgumentException("DistributionService requires a non-null OmnibusDelegate");
+        }
+        this.storage = storage;
+        this.omnibusDelegate = omnibusDelegate;
+    }
+
+    @Override
+    public DistributionStatus syncOmnibus(String assetId, AssetType assetType) {
+        String assetTypeStr = assetType.name().toLowerCase();
+        // Ensure the omnibus account row exists before we try to reconcile it; without this
+        // the UPDATE in syncOmnibusBalance touches zero rows and we'd never spot the divergence.
+        storage.ensureAccount(OMNIBUS_FIN_ID, assetId, assetTypeStr);
+        String onChainBalance = omnibusDelegate.getOmnibusBalance(assetId, assetType);
+        try {
+            DistributionTotals totals = storage.syncOmnibusBalance(
+                    OMNIBUS_FIN_ID, assetId, onChainBalance, assetTypeStr);
+            return new DistributionStatus(assetId, assetType,
+                    totals.omnibusBalance, totals.distributed, totals.available);
+        } catch (BusinessException e) {
+            throw e;
+        } catch (RuntimeException e) {
+            String msg = String.valueOf(e.getMessage());
+            // CHECK (balance >= 0) violation — on-chain balance is less than already-distributed
+            // total. Translate to a clearer BusinessException matching Node behavior.
+            if (msg.contains("accounts_balance_check") || msg.contains("accounts_check")) {
+                throw new BusinessException(1,
+                        "on-chain balance (" + onChainBalance + ") is less than already distributed");
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public DistributionStatus getDistributionStatus(String assetId, AssetType assetType) {
+        String assetTypeStr = assetType.name().toLowerCase();
+        DistributionTotals totals = storage.getDistributionStatus(OMNIBUS_FIN_ID, assetId, assetTypeStr);
+        return new DistributionStatus(assetId, assetType,
+                totals.omnibusBalance, totals.distributed, totals.available);
+    }
+
+    @Override
+    public void distribute(String finId, String assetId, AssetType assetType, String amount) {
+        String assetTypeStr = assetType.name().toLowerCase();
+        storage.ensureAccount(OMNIBUS_FIN_ID, assetId, assetTypeStr);
+        storage.ensureAccount(finId, assetId, assetTypeStr);
+        LedgerDetails details = new LedgerDetails(generateIdempotencyKey(), null, "distribute", null, null);
+        storage.move(OMNIBUS_FIN_ID, finId, amount, assetId, details, assetTypeStr);
+    }
+
+    @Override
+    public void reclaim(String finId, String assetId, AssetType assetType, String amount) {
+        String assetTypeStr = assetType.name().toLowerCase();
+        storage.ensureAccount(OMNIBUS_FIN_ID, assetId, assetTypeStr);
+        LedgerDetails details = new LedgerDetails(generateIdempotencyKey(), null, "reclaim", null, null);
+        storage.move(finId, OMNIBUS_FIN_ID, amount, assetId, details, assetTypeStr);
+    }
+
+    @Override
+    public DistributionStatus flushDistributions(String assetId, AssetType assetType) {
+        String assetTypeStr = assetType.name().toLowerCase();
+        List<DistributedAccount> accounts = storage.listDistributedAccounts(
+                OMNIBUS_FIN_ID, assetId, assetTypeStr);
+        logger.info("Flushing {} distributed account(s) for assetId={}", accounts.size(), assetId);
+        for (DistributedAccount account : accounts) {
+            reclaim(account.finId, assetId, assetType, account.balance);
+        }
+        return getDistributionStatus(assetId, assetType);
+    }
+
+    private static String generateIdempotencyKey() {
+        // Random 16-byte base64url id; uniqueness here is internal — these moves don't have a
+        // user-supplied idempotency key, so we generate one per call so the storage layer's
+        // dedup index doesn't conflate distinct distributions/reclaims.
+        byte[] bytes = new byte[16];
+        RNG.nextBytes(bytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+}

--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionService.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionService.java
@@ -96,8 +96,20 @@ public class VanillaDistributionService implements DistributionService {
         List<DistributedAccount> accounts = storage.listDistributedAccounts(
                 OMNIBUS_FIN_ID, assetId, assetTypeStr);
         logger.info("Flushing {} distributed account(s) for assetId={}", accounts.size(), assetId);
+        // Reclaim only the spendable portion (balance − held). An account with an outstanding
+        // escrow lock would trip the CHECK (held <= balance) constraint if we tried to move its
+        // full balance, and the flush would exit with earlier accounts already drained —
+        // leaving the asset in a partially-reclaimed state. Pulling just `available` always
+        // succeeds; the held portion stays put until the escrow is released or rolled back,
+        // and the caller can re-run flush afterwards. (Shared concern with the Node
+        // implementation; tracked there too.)
         for (DistributedAccount account : accounts) {
-            reclaim(account.finId, assetId, assetType, account.balance);
+            if ("0".equals(account.available)) {
+                logger.info("Skipping flush of fully-held account finId={} (balance={}, held={})",
+                        account.finId, account.balance, account.held);
+                continue;
+            }
+            reclaim(account.finId, assetId, assetType, account.available);
         }
         return getDistributionStatus(assetId, assetType);
     }

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
@@ -257,6 +257,25 @@ class LedgerStorageTest {
     }
 
     @Test
+    void listDistributedAccountsReportsBalanceHeldAndAvailable() {
+        String assetId = "asset-dist-held-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        storage.ensureAccount(OMNIBUS, assetId);
+        storage.ensureAccount(inv, assetId);
+        storage.credit(OMNIBUS, "1000", assetId, details("ik-seed-" + System.nanoTime(), "issue"));
+        storage.move(OMNIBUS, inv, "300", assetId, details("ik-m-" + System.nanoTime(), "distribute"));
+        // Lock 200 of the investor's 300 — typical mid-trade state.
+        storage.lock(inv, "200", assetId, details("ik-l-" + System.nanoTime(), "hold"));
+
+        java.util.List<DistributedAccount> rows = storage.listDistributedAccounts(OMNIBUS, assetId, "finp2p");
+        assertEquals(1, rows.size());
+        DistributedAccount row = rows.get(0);
+        assertEquals("300", row.balance);
+        assertEquals("200", row.held);
+        assertEquals("100", row.available, "derived available = balance − held");
+    }
+
+    @Test
     void getDistributionStatusReturnsOmnibusDistributedAvailableBreakdown() {
         String assetId = "asset-dist-status-" + System.nanoTime();
         String inv1 = "inv-1-" + System.nanoTime();

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/LedgerStorageTest.java
@@ -227,6 +227,103 @@ class LedgerStorageTest {
         assertEquals(created.id, found.id);
     }
 
+    // ─── Distribution queries ───────────────────────────────────────────────
+
+    private static final String OMNIBUS = "__omnibus__";
+
+    @Test
+    void listDistributedAccountsReturnsPositiveBalancesExcludingOmnibus() {
+        String assetId = "asset-dist-list-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        String inv2 = "inv-2-" + System.nanoTime();
+        String inv3Zero = "inv-3-" + System.nanoTime();
+        storage.ensureAccount(OMNIBUS, assetId);
+        storage.ensureAccount(inv1, assetId);
+        storage.ensureAccount(inv2, assetId);
+        storage.ensureAccount(inv3Zero, assetId);
+        storage.credit(OMNIBUS, "1000", assetId, details("ik-seed-" + System.nanoTime(), "issue"));
+        storage.move(OMNIBUS, inv1, "100", assetId, details("ik-m1-" + System.nanoTime(), "distribute"));
+        storage.move(OMNIBUS, inv2, "250", assetId, details("ik-m2-" + System.nanoTime(), "distribute"));
+        // inv3Zero exists but balance == 0 → must NOT appear.
+
+        java.util.List<DistributedAccount> rows = storage.listDistributedAccounts(OMNIBUS, assetId, "finp2p");
+        assertEquals(2, rows.size());
+        assertTrue(rows.stream().anyMatch(r -> r.finId.equals(inv1) && r.balance.equals("100")));
+        assertTrue(rows.stream().anyMatch(r -> r.finId.equals(inv2) && r.balance.equals("250")));
+        assertTrue(rows.stream().noneMatch(r -> r.finId.equals(OMNIBUS)),
+                "omnibus must be excluded regardless of its balance");
+        assertTrue(rows.stream().noneMatch(r -> r.finId.equals(inv3Zero)),
+                "zero-balance investor must not appear");
+    }
+
+    @Test
+    void getDistributionStatusReturnsOmnibusDistributedAvailableBreakdown() {
+        String assetId = "asset-dist-status-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        String inv2 = "inv-2-" + System.nanoTime();
+        storage.ensureAccount(OMNIBUS, assetId);
+        storage.ensureAccount(inv1, assetId);
+        storage.ensureAccount(inv2, assetId);
+        storage.credit(OMNIBUS, "1000", assetId, details("ik-seed-" + System.nanoTime(), "issue"));
+        storage.move(OMNIBUS, inv1, "150", assetId, details("ik-m1-" + System.nanoTime(), "distribute"));
+        storage.move(OMNIBUS, inv2, "200", assetId, details("ik-m2-" + System.nanoTime(), "distribute"));
+
+        DistributionTotals t = storage.getDistributionStatus(OMNIBUS, assetId, "finp2p");
+        assertEquals("650", t.available, "omnibus row balance after distributing 350");
+        assertEquals("350", t.distributed, "sum of inv1 + inv2");
+        assertEquals("1000", t.omnibusBalance, "available + distributed");
+    }
+
+    @Test
+    void getDistributionStatusReturnsZerosWhenAccountsDoNotExist() {
+        DistributionTotals t = storage.getDistributionStatus(OMNIBUS, "no-such-asset-" + System.nanoTime(), "finp2p");
+        assertEquals("0", t.omnibusBalance);
+        assertEquals("0", t.distributed);
+        assertEquals("0", t.available);
+    }
+
+    @Test
+    void syncOmnibusBalanceReconcilesAvailableAgainstDistributed() {
+        String assetId = "asset-sync-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        storage.ensureAccount(OMNIBUS, assetId);
+        storage.ensureAccount(inv1, assetId);
+        storage.credit(OMNIBUS, "500", assetId, details("ik-seed-" + System.nanoTime(), "issue"));
+        storage.move(OMNIBUS, inv1, "100", assetId, details("ik-m-" + System.nanoTime(), "distribute"));
+        // Local view: omnibus = 400 available, inv1 = 100, total = 500.
+
+        // Simulated on-chain balance reads 800 (e.g., a mint outside this adapter).
+        DistributionTotals t = storage.syncOmnibusBalance(OMNIBUS, assetId, "800", "finp2p");
+        assertEquals("800", t.omnibusBalance, "omnibusBalance echoes the caller's on-chain figure");
+        assertEquals("100", t.distributed, "distributed unchanged across sync");
+        assertEquals("700", t.available, "available = onChain - distributed");
+
+        // Storage state agrees.
+        assertEquals("700", storage.getBalance(OMNIBUS, assetId).balance);
+        assertEquals("100", storage.getBalance(inv1, assetId).balance);
+    }
+
+    @Test
+    void syncOmnibusBalanceLessThanDistributedTripsBalanceCheck() {
+        String assetId = "asset-sync-low-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        storage.ensureAccount(OMNIBUS, assetId);
+        storage.ensureAccount(inv1, assetId);
+        storage.credit(OMNIBUS, "300", assetId, details("ik-seed-" + System.nanoTime(), "issue"));
+        storage.move(OMNIBUS, inv1, "200", assetId, details("ik-m-" + System.nanoTime(), "distribute"));
+        // distributed = 200, omnibus available = 100, total = 300.
+
+        // On-chain reports 150 — less than the 200 we've already distributed. The UPDATE would
+        // push omnibus balance to -50 and trip CHECK (balance >= 0). Storage surfaces this as a
+        // RuntimeException; the service layer translates it into a BusinessException.
+        assertThrows(RuntimeException.class, () ->
+                storage.syncOmnibusBalance(OMNIBUS, assetId, "150", "finp2p"));
+
+        // State unchanged after the failed sync (the constraint aborted the whole statement).
+        assertEquals("100", storage.getBalance(OMNIBUS, assetId).balance);
+        assertEquals("200", storage.getBalance(inv1, assetId).balance);
+    }
+
     @Test
     void findByOperationIdReturnsLatestWhenMultipleRowsShareOperationId() throws Exception {
         // hold + release + redeem all stamp the caller's operation_id into details, so the

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionServiceTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionServiceTest.java
@@ -126,6 +126,62 @@ class VanillaDistributionServiceTest {
     }
 
     @Test
+    void flushDistributionsReclaimsAvailableAndLeavesHeldBalancesInPlace() {
+        // Reviewer-flagged: flush used to enumerate raw balance and try to reclaim the full
+        // amount, which would trip CHECK(held <= balance) on any account with an outstanding
+        // hold — and worse, leave the asset partially flushed because earlier loop iterations
+        // had already drained other investors. The fix moves only the spendable portion;
+        // held value stays put and the flush completes cleanly across every investor.
+        String assetId = "asset-flush-held-" + System.nanoTime();
+        // Order the finIds so the all-available account flushes BEFORE the partially-held
+        // one. Under the old behavior that ordering was exactly the trap: inv1 would be
+        // drained, then the loop would throw on inv2 mid-flush.
+        String inv1 = "aaa-" + System.nanoTime();
+        String inv2 = "bbb-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "1000", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv1, assetId, AssetType.FINP2P, "300");
+        service.distribute(inv2, assetId, AssetType.FINP2P, "400");
+        // Tie up part of inv2's balance in an escrow lock.
+        storage.lock(inv2, "250", assetId,
+                new LedgerDetails("hold-" + System.nanoTime(), "op-x", "hold", null, null));
+
+        DistributionStatus s = service.flushDistributions(assetId, AssetType.FINP2P);
+
+        // inv1 fully drained, inv2 keeps its 250 held value (balance == held); the available
+        // 150 was reclaimed.
+        assertEquals("0",   storage.getBalance(inv1, assetId).balance);
+        assertEquals("250", storage.getBalance(inv2, assetId).balance,
+                "held portion must remain on the investor row");
+        assertEquals("250", storage.getBalance(inv2, assetId).held);
+        // Post-flush status: omnibus rehydrated by 850 (300 + 150), 250 still "distributed".
+        assertEquals("1000", s.omnibusBalance);
+        assertEquals("250",  s.distributedBalance);
+        assertEquals("750",  s.availableBalance);
+    }
+
+    @Test
+    void flushDistributionsSkipsFullyHeldAccount() {
+        String assetId = "asset-flush-allheld-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "500", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv, assetId, AssetType.FINP2P, "200");
+        storage.lock(inv, "200", assetId,
+                new LedgerDetails("hold-" + System.nanoTime(), "op-y", "hold", null, null));
+
+        DistributionStatus s = service.flushDistributions(assetId, AssetType.FINP2P);
+
+        // Nothing spendable to reclaim — investor row is untouched.
+        assertEquals("200", storage.getBalance(inv, assetId).balance);
+        assertEquals("200", storage.getBalance(inv, assetId).held);
+        assertEquals("300", s.availableBalance, "omnibus still at 300 (no flush moved anything)");
+        assertEquals("200", s.distributedBalance);
+    }
+
+    @Test
     void flushDistributionsReclaimsAllInvestorBalances() {
         String assetId = "asset-flush-" + System.nanoTime();
         String inv1 = "inv-1-" + System.nanoTime();

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionServiceTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaDistributionServiceTest.java
@@ -1,0 +1,151 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import io.ownera.ledger.adapter.service.BusinessException;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration tests for {@link VanillaDistributionService}: each {@code DistributionService}
+ * method exercised against the real {@link LedgerStorage}, with the on-chain balance source
+ * stubbed via Mockito.
+ */
+class VanillaDistributionServiceTest {
+
+    private LedgerStorage storage;
+    private OmnibusDelegate omnibusDelegate;
+    private VanillaDistributionService service;
+
+    @BeforeEach
+    void setup() {
+        storage = new LedgerStorage(VanillaPostgresHolder.CTX, VanillaPostgresHolder.SCHEMA);
+        omnibusDelegate = Mockito.mock(OmnibusDelegate.class);
+        service = new VanillaDistributionService(storage, omnibusDelegate);
+    }
+
+    @Test
+    void constructorRejectsNullOmnibusDelegate() {
+        // Delegate is the source of truth for on-chain balance; constructing without one is a
+        // wiring mistake, so fail fast.
+        assertThrows(IllegalArgumentException.class,
+                () -> new VanillaDistributionService(storage, null));
+    }
+
+    @Test
+    void distributeMovesValueFromOmnibusToInvestor() {
+        String assetId = "asset-dist-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        // Seed omnibus with a known on-chain balance so the move has funds to draw from.
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "1000", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+
+        service.distribute(inv, assetId, AssetType.FINP2P, "300");
+
+        assertEquals("700", storage.getBalance(VanillaDistributionService.OMNIBUS_FIN_ID, assetId).balance);
+        assertEquals("300", storage.getBalance(inv, assetId).balance);
+    }
+
+    @Test
+    void reclaimMovesValueFromInvestorBackToOmnibus() {
+        String assetId = "asset-reclaim-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "500", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv, assetId, AssetType.FINP2P, "200");
+
+        service.reclaim(inv, assetId, AssetType.FINP2P, "150");
+
+        assertEquals("50",  storage.getBalance(inv, assetId).balance);
+        assertEquals("450", storage.getBalance(VanillaDistributionService.OMNIBUS_FIN_ID, assetId).balance);
+    }
+
+    @Test
+    void getDistributionStatusReturnsBreakdown() {
+        String assetId = "asset-status-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        String inv2 = "inv-2-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "1000", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv1, assetId, AssetType.FINP2P, "300");
+        service.distribute(inv2, assetId, AssetType.FINP2P, "200");
+
+        DistributionStatus s = service.getDistributionStatus(assetId, AssetType.FINP2P);
+        assertEquals(assetId, s.assetId);
+        assertEquals(AssetType.FINP2P, s.assetType);
+        assertEquals("1000", s.omnibusBalance);
+        assertEquals("500",  s.distributedBalance);
+        assertEquals("500",  s.availableBalance);
+    }
+
+    @Test
+    void syncOmnibusReconcilesAgainstDelegate() {
+        String assetId = "asset-sync-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "500", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv, assetId, AssetType.FINP2P, "200");
+        // Local view: omnibus available = 300, distributed = 200, total = 500.
+
+        Mockito.when(omnibusDelegate.getOmnibusBalance(assetId, AssetType.FINP2P)).thenReturn("700");
+
+        DistributionStatus s = service.syncOmnibus(assetId, AssetType.FINP2P);
+        assertEquals("700", s.omnibusBalance);
+        assertEquals("200", s.distributedBalance);
+        assertEquals("500", s.availableBalance, "on-chain 700 − already-distributed 200");
+
+        assertEquals("500", storage.getBalance(VanillaDistributionService.OMNIBUS_FIN_ID, assetId).balance);
+    }
+
+    @Test
+    void syncOmnibusThrowsBusinessExceptionWhenOnChainLessThanDistributed() {
+        String assetId = "asset-sync-bad-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "500", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv, assetId, AssetType.FINP2P, "400");
+
+        // On-chain reports 200 — less than the 400 already distributed.
+        Mockito.when(omnibusDelegate.getOmnibusBalance(assetId, AssetType.FINP2P)).thenReturn("200");
+
+        BusinessException e = assertThrows(BusinessException.class,
+                () -> service.syncOmnibus(assetId, AssetType.FINP2P));
+        assertTrue(e.getMessage().contains("200"), e.getMessage());
+        assertTrue(e.getMessage().toLowerCase().contains("distributed"), e.getMessage());
+
+        // State unchanged after the failed sync.
+        assertEquals("100", storage.getBalance(VanillaDistributionService.OMNIBUS_FIN_ID, assetId).balance);
+        assertEquals("400", storage.getBalance(inv, assetId).balance);
+    }
+
+    @Test
+    void flushDistributionsReclaimsAllInvestorBalances() {
+        String assetId = "asset-flush-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        String inv2 = "inv-2-" + System.nanoTime();
+        String inv3 = "inv-3-" + System.nanoTime();
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, "1000", assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+        service.distribute(inv1, assetId, AssetType.FINP2P, "300");
+        service.distribute(inv2, assetId, AssetType.FINP2P, "200");
+        service.distribute(inv3, assetId, AssetType.FINP2P, "100");
+
+        DistributionStatus afterFlush = service.flushDistributions(assetId, AssetType.FINP2P);
+
+        assertEquals("1000", afterFlush.omnibusBalance);
+        assertEquals("0",    afterFlush.distributedBalance);
+        assertEquals("1000", afterFlush.availableBalance);
+        // Each investor row is zeroed.
+        assertEquals("0", storage.getBalance(inv1, assetId).balance);
+        assertEquals("0", storage.getBalance(inv2, assetId).balance);
+        assertEquals("0", storage.getBalance(inv3, assetId).balance);
+    }
+}

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/web/DistributionControllerTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/web/DistributionControllerTest.java
@@ -1,0 +1,205 @@
+package io.ownera.ledger.adapter.vanilla.web;
+
+import io.ownera.ledger.adapter.service.model.AssetType;
+import io.ownera.ledger.adapter.vanilla.DistributionStatus;
+import io.ownera.ledger.adapter.vanilla.LedgerDetails;
+import io.ownera.ledger.adapter.vanilla.LedgerStorage;
+import io.ownera.ledger.adapter.vanilla.OmnibusDelegate;
+import io.ownera.ledger.adapter.vanilla.VanillaDistributionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * End-to-end HTTP tests for the {@code /distribution/*} routes via {@link TestRestTemplate}.
+ * Verifies each route's status code, response shape, and side effects on the underlying
+ * {@link LedgerStorage}.
+ */
+@SpringBootTest(
+        classes = DistributionTestApplication.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class DistributionControllerTest {
+
+    @Autowired
+    private TestRestTemplate rest;
+
+    @Autowired
+    private LedgerStorage storage;
+
+    @Autowired
+    private OmnibusDelegate omnibusDelegate;
+
+    @BeforeEach
+    void resetMocks() {
+        Mockito.reset(omnibusDelegate);
+    }
+
+    private void seedOmnibus(String assetId, String balance) {
+        storage.ensureAccount(VanillaDistributionService.OMNIBUS_FIN_ID, assetId);
+        storage.credit(VanillaDistributionService.OMNIBUS_FIN_ID, balance, assetId,
+                new LedgerDetails("seed-" + System.nanoTime(), null, "issue", null, null));
+    }
+
+    private static <T> HttpEntity<T> json(T body) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return new HttpEntity<>(body, headers);
+    }
+
+    @Test
+    void getStatusReturnsDistributionStatusForAsset() {
+        String assetId = "asset-status-" + System.nanoTime();
+        seedOmnibus(assetId, "1000");
+
+        ResponseEntity<DistributionStatus> resp = rest.getForEntity(
+                "/distribution/status?assetId=" + assetId, DistributionStatus.class);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        DistributionStatus s = resp.getBody();
+        assertNotNull(s);
+        assertEquals(assetId, s.assetId);
+        assertEquals(AssetType.FINP2P, s.assetType);
+        assertEquals("1000", s.omnibusBalance);
+        assertEquals("0",    s.distributedBalance);
+        assertEquals("1000", s.availableBalance);
+    }
+
+    @Test
+    void getStatusRejectsMissingAssetId() {
+        ResponseEntity<Map> resp = rest.getForEntity(
+                "/distribution/status", Map.class);
+        // Spring's @RequestParam without `required=false` returns 400 itself; either way the
+        // route must NOT 200.
+        assertNotEquals(200, resp.getStatusCodeValue());
+    }
+
+    @Test
+    void postDistributeMovesValueFromOmnibusToInvestor() {
+        String assetId = "asset-dist-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        seedOmnibus(assetId, "500");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("finId", inv);
+        body.put("assetId", assetId);
+        body.put("amount", "150");
+
+        ResponseEntity<Map> resp = rest.postForEntity("/distribution/distribute", json(body), Map.class);
+        assertEquals(200, resp.getStatusCodeValue());
+        assertEquals("ok", resp.getBody().get("status"));
+
+        assertEquals("350", storage.getBalance(VanillaDistributionService.OMNIBUS_FIN_ID, assetId).balance);
+        assertEquals("150", storage.getBalance(inv, assetId).balance);
+    }
+
+    @Test
+    void postDistributeRejectsMissingFields() {
+        Map<String, Object> body = new HashMap<>();
+        body.put("assetId", "asset-X");
+        // finId + amount missing
+        ResponseEntity<Map> resp = rest.postForEntity("/distribution/distribute", json(body), Map.class);
+        assertEquals(400, resp.getStatusCodeValue());
+        assertNotNull(resp.getBody());
+        assertNotNull(resp.getBody().get("error"));
+    }
+
+    @Test
+    void postReclaimMovesValueFromInvestorBackToOmnibus() {
+        String assetId = "asset-reclaim-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        seedOmnibus(assetId, "500");
+        // Pre-distribute so reclaim has something to pull back.
+        VanillaDistributionService svc = new VanillaDistributionService(storage, omnibusDelegate);
+        svc.distribute(inv, assetId, AssetType.FINP2P, "200");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("finId", inv);
+        body.put("assetId", assetId);
+        body.put("amount", "120");
+
+        ResponseEntity<Map> resp = rest.postForEntity("/distribution/reclaim", json(body), Map.class);
+        assertEquals(200, resp.getStatusCodeValue());
+
+        assertEquals("80",  storage.getBalance(inv, assetId).balance);
+        assertEquals("420", storage.getBalance(VanillaDistributionService.OMNIBUS_FIN_ID, assetId).balance);
+    }
+
+    @Test
+    void postSyncReconcilesAgainstDelegate() {
+        String assetId = "asset-sync-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        seedOmnibus(assetId, "500");
+        new VanillaDistributionService(storage, omnibusDelegate)
+                .distribute(inv, assetId, AssetType.FINP2P, "200");
+
+        Mockito.when(omnibusDelegate.getOmnibusBalance(assetId, AssetType.FINP2P)).thenReturn("700");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("assetId", assetId);
+        ResponseEntity<DistributionStatus> resp = rest.postForEntity(
+                "/distribution/sync", json(body), DistributionStatus.class);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        DistributionStatus s = resp.getBody();
+        assertNotNull(s);
+        assertEquals("700", s.omnibusBalance);
+        assertEquals("200", s.distributedBalance);
+        assertEquals("500", s.availableBalance);
+    }
+
+    @Test
+    void postSyncReturns409WhenOnChainLessThanDistributed() {
+        String assetId = "asset-sync-bad-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        seedOmnibus(assetId, "500");
+        new VanillaDistributionService(storage, omnibusDelegate)
+                .distribute(inv, assetId, AssetType.FINP2P, "400");
+
+        // On-chain reports 200 — less than the 400 already distributed.
+        Mockito.when(omnibusDelegate.getOmnibusBalance(assetId, AssetType.FINP2P)).thenReturn("200");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("assetId", assetId);
+        ResponseEntity<Map> resp = rest.postForEntity("/distribution/sync", json(body), Map.class);
+
+        assertEquals(409, resp.getStatusCodeValue());
+        assertNotNull(resp.getBody().get("error"));
+        assertTrue(resp.getBody().get("error").toString().contains("200"));
+    }
+
+    @Test
+    void postFlushReclaimsEveryInvestorBack() {
+        String assetId = "asset-flush-" + System.nanoTime();
+        String inv1 = "inv-1-" + System.nanoTime();
+        String inv2 = "inv-2-" + System.nanoTime();
+        seedOmnibus(assetId, "1000");
+        VanillaDistributionService svc = new VanillaDistributionService(storage, omnibusDelegate);
+        svc.distribute(inv1, assetId, AssetType.FINP2P, "300");
+        svc.distribute(inv2, assetId, AssetType.FINP2P, "200");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("assetId", assetId);
+        ResponseEntity<DistributionStatus> resp = rest.postForEntity(
+                "/distribution/flush", json(body), DistributionStatus.class);
+
+        assertEquals(200, resp.getStatusCodeValue());
+        DistributionStatus s = resp.getBody();
+        assertEquals("1000", s.omnibusBalance);
+        assertEquals("0",    s.distributedBalance);
+        assertEquals("1000", s.availableBalance);
+        assertEquals("0", storage.getBalance(inv1, assetId).balance);
+        assertEquals("0", storage.getBalance(inv2, assetId).balance);
+    }
+}

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/web/DistributionControllerTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/web/DistributionControllerTest.java
@@ -77,6 +77,55 @@ class DistributionControllerTest {
     }
 
     @Test
+    void getStatusEmitsLowercaseAssetTypeMatchingNodeWire() throws Exception {
+        // Reviewer-flagged: the wire shape for assetType must be lowercase to round-trip with
+        // the Node distribution surface. Deserializing into DistributionStatus would mask an
+        // uppercase serialization, so this test inspects the raw JSON body.
+        String assetId = "asset-wire-out-" + System.nanoTime();
+        seedOmnibus(assetId, "100");
+
+        ResponseEntity<String> resp = rest.getForEntity(
+                "/distribution/status?assetId=" + assetId, String.class);
+        assertEquals(200, resp.getStatusCodeValue());
+        com.fasterxml.jackson.databind.JsonNode body =
+                new com.fasterxml.jackson.databind.ObjectMapper().readTree(resp.getBody());
+        assertEquals("finp2p", body.get("assetType").asText(),
+                "response must serialize assetType as the Node-style lowercase form");
+    }
+
+    @Test
+    void getStatusAcceptsLowercaseAssetTypeQueryParameter() {
+        // Symmetric input case: Node-style ?assetType=finp2p must not 400.
+        String assetId = "asset-wire-in-" + System.nanoTime();
+        seedOmnibus(assetId, "100");
+
+        ResponseEntity<DistributionStatus> resp = rest.getForEntity(
+                "/distribution/status?assetId=" + assetId + "&assetType=finp2p",
+                DistributionStatus.class);
+        assertEquals(200, resp.getStatusCodeValue());
+        assertEquals(AssetType.FINP2P, resp.getBody().assetType);
+    }
+
+    @Test
+    void postDistributeAcceptsLowercaseAssetTypeInRequestBody() {
+        // Request bodies go through Jackson — the @JsonCreator on AssetType must accept
+        // lowercase. Without it, "assetType":"finp2p" deserialization throws and we 400.
+        String assetId = "asset-body-in-" + System.nanoTime();
+        String inv = "inv-" + System.nanoTime();
+        seedOmnibus(assetId, "300");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("finId", inv);
+        body.put("assetId", assetId);
+        body.put("assetType", "finp2p"); // Node-style lowercase
+        body.put("amount", "100");
+
+        ResponseEntity<Map> resp = rest.postForEntity("/distribution/distribute", json(body), Map.class);
+        assertEquals(200, resp.getStatusCodeValue(), "lowercase assetType in body must not 400");
+        assertEquals("100", storage.getBalance(inv, assetId).balance);
+    }
+
+    @Test
     void getStatusRejectsMissingAssetId() {
         ResponseEntity<Map> resp = rest.getForEntity(
                 "/distribution/status", Map.class);

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/web/DistributionTestApplication.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/web/DistributionTestApplication.java
@@ -1,0 +1,63 @@
+package io.ownera.ledger.adapter.vanilla.web;
+
+import io.ownera.ledger.adapter.vanilla.DistributionRoutesConfig;
+import io.ownera.ledger.adapter.vanilla.DistributionService;
+import io.ownera.ledger.adapter.vanilla.LedgerStorage;
+import io.ownera.ledger.adapter.vanilla.OmnibusDelegate;
+import io.ownera.ledger.adapter.vanilla.VanillaDistributionService;
+import io.ownera.ledger.adapter.vanilla.VanillaPostgresHolder;
+import org.jooq.DSLContext;
+import org.mockito.Mockito;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Minimal Spring Boot bootstrap for {@link DistributionControllerTest}.
+ *
+ * <p>Vanilla-service is a library; this class only exists so the test can run the
+ * {@code /distribution/*} routes behind a real HTTP server. It plays the role of an
+ * adapter: provides a {@link DistributionService} bean (built from the shared
+ * {@link LedgerStorage} + a mocked {@link OmnibusDelegate}) and opts into the routes with
+ * {@code @Import(DistributionRoutesConfig.class)} — exactly what a real adapter would do.
+ *
+ * <p>The bootstrap deliberately lives in {@code …vanilla.web} (a sub-package of vanilla's
+ * production root). {@code @SpringBootApplication} default component-scan starts at this
+ * class's package and goes <em>down</em>, so {@code DistributionController} at
+ * {@code …vanilla} is <strong>not</strong> auto-scanned — the only path that registers the
+ * controller bean is the {@code @Import(DistributionRoutesConfig.class)} below, mirroring
+ * what a real adapter does.
+ *
+ * <p>DataSource auto-configuration is excluded because we provide the jOOQ
+ * {@link DSLContext} directly from the test container.
+ */
+@SpringBootApplication(exclude = DataSourceAutoConfiguration.class)
+@Import(DistributionRoutesConfig.class)
+public class DistributionTestApplication {
+
+    @Bean
+    public DSLContext dslContext() {
+        return VanillaPostgresHolder.CTX;
+    }
+
+    @Bean
+    public LedgerStorage ledgerStorage(DSLContext dsl) {
+        return new LedgerStorage(dsl, VanillaPostgresHolder.SCHEMA);
+    }
+
+    @Bean
+    public OmnibusDelegate omnibusDelegate() {
+        return Mockito.mock(OmnibusDelegate.class);
+    }
+
+    @Bean
+    public DistributionService distributionService(LedgerStorage storage, OmnibusDelegate delegate) {
+        return new VanillaDistributionService(storage, delegate);
+    }
+
+    public static void main(String[] args) {
+        SpringApplication.run(DistributionTestApplication.class, args);
+    }
+}


### PR DESCRIPTION
## Summary

Adds `DistributionService` on top of PR 2's vanilla ledger, mirroring Node's [`vanilla-service/src/service.ts`](https://github.com/owneraio/finp2p-nodejs-skeleton-adapter/blob/master/vanilla-service/src/service.ts) distribution methods and [`vanilla-service/src/routes.ts`](https://github.com/owneraio/finp2p-nodejs-skeleton-adapter/blob/master/vanilla-service/src/routes.ts) opt-in route registration. Fourth in the PR sequence after #48 / #49 / #50.

## Decisions

- **Routes location**: shipped as `DistributionController` (`@RestController`) inside vanilla-service, with `DistributionRoutesConfig` as the opt-in entry point. Vanilla stays a library — adapters wire the routes with `@Import(DistributionRoutesConfig.class)`, mirroring Node's `registerDistributionRoutes(app, service)` callback. Component-scan won't auto-discover the controller across adapter package roots.
- **Sample-adapter wiring**: none (consistent with PR 2).
- **OmnibusDelegate**: required (non-null) at construction. Distribution can't function without an on-chain source of truth, so we fail fast.

## What's in

**Storage** — three new queries on `LedgerStorage`, all built via the existing `String.format(*_TEMPLATE, table)` pattern (precomputed once per instance):
- `listDistributedAccounts(omnibus, asset)` — investor rows with `balance > 0`, omnibus excluded.
- `getDistributionStatus(omnibus, asset)` — omnibus + distributed + available in one SELECT.
- `syncOmnibusBalance(omnibus, asset, onChain)` — atomic UPDATE under the same per-asset advisory lock as `transfer()`; `CHECK (balance >= 0)` catches an on-chain balance below the already-distributed total.

**Types**:
- `OmnibusDelegate` — read-only on-chain balance fetch (`getOmnibusBalance(assetId, assetType)`).
- `DistributedAccount`, `DistributionTotals` — storage-layer DTOs.
- `DistributionStatus` — wire shape (`assetId + assetType + omnibusBalance + distributedBalance + availableBalance`).
- `DistributionService` — interface mirroring Node's.

**`VanillaDistributionService`**:
- `OMNIBUS_FIN_ID = "__omnibus__"` sentinel.
- `syncOmnibus` translates the storage CHECK violation into `BusinessException("on-chain balance (X) is less than already distributed")` — matches Node.
- `distribute` / `reclaim` move value via `storage.move` with a fresh idempotency key per call.
- `flushDistributions` iterates `listDistributedAccounts` and reclaims each row.

**Routes (opt-in)**:
- `DistributionController` — `@RestController` exposing `POST /distribution/sync`, `GET /distribution/status`, `POST /distribution/distribute`, `POST /distribution/reclaim`, `POST /distribution/flush`. `BusinessException` → 409, `IllegalArgumentException` → 400.
- `DistributionRoutesConfig` — `@Configuration` that declares the controller as a `@Bean`. Adapter imports this and provides a `DistributionService` bean.

## Tests (15 new; 76 in vanilla-service, ~123 in the reactor)

- `LedgerStorageTest` (5) — listDistributedAccounts excludes omnibus + zero balances; getDistributionStatus's breakdown and zero-fallback; syncOmnibusBalance's reconciliation and CHECK-trip when on-chain < distributed.
- `VanillaDistributionServiceTest` (7) — null-delegate rejection; distribute/reclaim/flush/status/sync happy paths; sync surfacing a `BusinessException` with the offending on-chain balance in the message.
- `DistributionControllerTest` (8) — full HTTP round-trip via `TestRestTemplate` for every route; validation 400s; sync conflict 409. Wired by a minimal `DistributionTestApplication` in `…vanilla.web` so default component-scan doesn't auto-pick-up the controller; routes are wired explicitly via `@Import(DistributionRoutesConfig.class)`, exactly like a real adapter would.

## Test plan

- [ ] CI: build + tests
- [ ] CodeQL: java-kotlin analyzer

🤖 Generated with [Claude Code](https://claude.com/claude-code)