### PR TITLE
Let InboundTransferHook deliberately reject plans

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
@@ -178,6 +178,10 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
                                         asset,
                                         destFinId, transfer.getAmount(),
                                         instructionSequence, null));
+                    } catch (InboundTransferRejection r) {
+                        logger.info("Inbound transfer rejected by hook: plan={}, seq={}, code={}, msg={}",
+                                planId, instructionSequence, r.getCode(), r.getMessage());
+                        return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
                     } catch (Exception e) {
                         logger.warn("Inbound transfer hook failed: {}", e.getMessage());
                     }
@@ -247,6 +251,10 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
                                     asset,
                                     finIdOf(transfer.getDestination()),
                                     transfer.getAmount()));
+                } catch (InboundTransferRejection r) {
+                    logger.info("Planned inbound transfer rejected by hook: plan={}, code={}, msg={}",
+                            planId, r.getCode(), r.getMessage());
+                    return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
                 } catch (Exception e) {
                     logger.warn("Planned inbound transfer hook failed: {}", e.getMessage());
                 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferHook.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferHook.java
@@ -6,16 +6,23 @@ import javax.annotation.Nullable;
 
 /**
  * Hook for inbound transfer notifications during plan execution.
+ *
+ * <p><strong>Rejecting:</strong> throw {@link InboundTransferRejection} to deliberately reject
+ * the plan with a supplied error {@code code} / {@code message}. Any other exception is
+ * treated as a hook bug — warn-logged, otherwise ignored — so unrelated failures don't
+ * silently fail-close legitimate plans.
  */
 public interface InboundTransferHook {
 
     /**
-     * Called during plan approval when a planned inbound transfer is detected.
+     * Called during plan approval when a planned inbound transfer is detected. Throw
+     * {@link InboundTransferRejection} to reject the plan.
      */
     void onPlannedInboundTransfer(String idempotencyKey, PlannedInboundTransferContext ctx);
 
     /**
-     * Called after an instruction-level proposal is executed for an inbound transfer.
+     * Called after an instruction-level proposal is executed for an inbound transfer. Throw
+     * {@link InboundTransferRejection} to reject the proposal.
      */
     void onInboundTransfer(String idempotencyKey, InboundTransferContext ctx);
 

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferRejection.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferRejection.java
@@ -1,0 +1,25 @@
+package io.ownera.ledger.adapter.service.plan;
+
+/**
+ * Thrown by an {@link InboundTransferHook} to reject an inbound transfer during plan approval
+ * or instruction-level proposal. The framework catches this specifically and converts it to a
+ * {@code RejectedPlan} response with the supplied {@code code} / {@code message}.
+ *
+ * <p>Any other exception escaping a hook is treated as a hook bug — warn-logged and otherwise
+ * ignored (the plan is still approved). That distinction matters: it keeps unrelated hook
+ * failures from accidentally fail-closing legitimate plans, while giving adapters a typed
+ * "deliberate reject" channel.
+ */
+public class InboundTransferRejection extends RuntimeException {
+
+    private final int code;
+
+    public InboundTransferRejection(int code, String message) {
+        super(message);
+        this.code = code;
+    }
+
+    public int getCode() {
+        return code;
+    }
+}

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferRejectionTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferRejectionTest.java
@@ -1,0 +1,171 @@
+package io.ownera.ledger.adapter.service.plan;
+
+import io.ownera.finp2p.OperationalSDK;
+import io.ownera.finp2p.opapi.model.Execution;
+import io.ownera.finp2p.opapi.model.ExecutionInstruction;
+import io.ownera.finp2p.opapi.model.ExecutionPlan;
+import io.ownera.finp2p.opapi.model.ExecutionPlanOperation;
+import io.ownera.finp2p.opapi.model.FinIdAccount1;
+import io.ownera.finp2p.opapi.model.Finp2pAsset;
+import io.ownera.finp2p.opapi.model.Finp2pAssetAccount;
+import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
+import io.ownera.finp2p.opapi.model.TransferInstruction;
+import io.ownera.ledger.adapter.service.model.ApprovedPlan;
+import io.ownera.ledger.adapter.service.model.PlanApprovalStatus;
+import io.ownera.ledger.adapter.service.model.RejectedPlan;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that {@link InboundTransferRejection} thrown by an {@link InboundTransferHook} is
+ * caught specifically and converted into a {@code RejectedPlan} (carrying the supplied code +
+ * message), while any other exception escaping the hook is treated as a hook bug — warn-logged,
+ * approval still proceeds. The asymmetry is the whole point of the typed-rejection channel:
+ * deliberate reject vs accidental hook failure must produce different outcomes.
+ */
+class InboundTransferRejectionTest {
+
+    private OperationalSDK sdk;
+
+    @BeforeEach
+    void setup() {
+        sdk = Mockito.mock(OperationalSDK.class);
+    }
+
+    @Test
+    void approvePlanRejectsWhenPlannedHookThrowsInboundTransferRejection() throws Exception {
+        String planId = "plan-reject-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(executionWithTransfer(planId, 1, "org-test"));
+
+        InboundTransferHook hook = new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) {
+                throw new InboundTransferRejection(403, "destination not whitelisted");
+            }
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) {}
+        };
+
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, null, hook, null);
+
+        PlanApprovalStatus status = svc.approvePlan("ik-" + System.nanoTime(), planId);
+        assertTrue(status instanceof RejectedPlan, "InboundTransferRejection must produce RejectedPlan, got " + status.getClass());
+        RejectedPlan rejected = (RejectedPlan) status;
+        assertEquals(403, rejected.details.code);
+        assertEquals("destination not whitelisted", rejected.details.message);
+    }
+
+    @Test
+    void approvePlanContinuesWhenPlannedHookThrowsOtherException() throws Exception {
+        // A hook bug (NullPointerException, IllegalStateException, whatever) must NOT silently
+        // fail-close a legitimate plan. It's warn-logged and approval continues.
+        String planId = "plan-bug-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(executionWithTransfer(planId, 1, "org-test"));
+
+        InboundTransferHook hook = new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) {
+                throw new RuntimeException("oops — hook bug");
+            }
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) {}
+        };
+
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, null, hook, null);
+
+        PlanApprovalStatus status = svc.approvePlan("ik-" + System.nanoTime(), planId);
+        assertTrue(status instanceof ApprovedPlan, "non-typed hook failure must not reject the plan, got " + status.getClass());
+    }
+
+    @Test
+    void proposeInstructionApprovalRejectsWhenHookThrowsInboundTransferRejection() throws Exception {
+        String planId = "plan-instr-reject-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(executionWithTransfer(planId, 7, "org-test"));
+
+        InboundTransferHook hook = new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) {}
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) {
+                throw new InboundTransferRejection(409, "on-chain settlement missing");
+            }
+        };
+
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, null, hook, null);
+
+        PlanApprovalStatus status = svc.proposeInstructionApproval("ik-" + System.nanoTime(), planId, 7);
+        assertTrue(status instanceof RejectedPlan, "instruction-level reject must produce RejectedPlan, got " + status.getClass());
+        RejectedPlan rejected = (RejectedPlan) status;
+        assertEquals(409, rejected.details.code);
+        assertEquals("on-chain settlement missing", rejected.details.message);
+    }
+
+    @Test
+    void proposeInstructionApprovalApprovesWhenHookThrowsOtherException() throws Exception {
+        String planId = "plan-instr-bug-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(executionWithTransfer(planId, 7, "org-test"));
+
+        InboundTransferHook hook = new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) {}
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) {
+                throw new IllegalStateException("hook is broken");
+            }
+        };
+
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, null, hook, null);
+
+        PlanApprovalStatus status = svc.proposeInstructionApproval("ik-" + System.nanoTime(), planId, 7);
+        assertTrue(status instanceof ApprovedPlan, "non-typed hook failure must not reject the instruction, got " + status.getClass());
+    }
+
+    /**
+     * Build a minimal Execution with a single TransferInstruction assigned to {@code orgId} at
+     * the given {@code sequence}. Source and destination are populated enough for the helpers in
+     * DefaultPlanApprovalService to extract a fin-id and asset id without NPE.
+     */
+    private static Execution executionWithTransfer(String planId, int sequence, String orgId) {
+        FinIdAccount1 srcFin = new FinIdAccount1();
+        srcFin.setFinId("src-fin-id");
+        FinIdAccount1 dstFin = new FinIdAccount1();
+        dstFin.setFinId("dst-fin-id");
+
+        Finp2pAsset asset = new Finp2pAsset();
+        asset.setId("asset-1");
+
+        Finp2pAssetAccount srcAcct = new Finp2pAssetAccount();
+        srcAcct.setAccount(srcFin);
+        srcAcct.setAsset(asset);
+        Finp2pAssetAccount dstAcct = new Finp2pAssetAccount();
+        dstAcct.setAccount(dstFin);
+        dstAcct.setAsset(asset);
+
+        LedgerAccountAsset src = new LedgerAccountAsset();
+        src.setFinp2pAccount(srcAcct);
+        LedgerAccountAsset dst = new LedgerAccountAsset();
+        dst.setFinp2pAccount(dstAcct);
+
+        TransferInstruction transfer = new TransferInstruction();
+        transfer.setSource(src);
+        transfer.setDestination(dst);
+        transfer.setAmount("100");
+
+        ExecutionPlanOperation op = new ExecutionPlanOperation();
+        op.setActualInstance(transfer);
+
+        ExecutionInstruction instr = new ExecutionInstruction();
+        instr.setSequence(sequence);
+        instr.setOrganizations(Collections.singletonList(orgId));
+        instr.setExecutionPlanOperation(op);
+
+        ExecutionPlan plan = new ExecutionPlan();
+        plan.setId(planId);
+        plan.setInstructions(Collections.singletonList(instr));
+
+        Execution exec = new Execution();
+        exec.setPlan(plan);
+        return exec;
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce typed `InboundTransferRejection(code, message)` exception so adapters can deliberately reject inbound transfers from `onPlannedInboundTransfer` / `onInboundTransfer`.
- `DefaultPlanApprovalService` catches it specifically and returns `RejectedPlan(new ErrorDetails(code, message))`; any other exception keeps the existing warn-log fallback so a buggy hook can't silently fail-close legitimate plans.
- 4 new tests verify both paths at both hook call sites; full reactor green (15 + 67 + 73 = 155).

## Usage
```java
@Override
public void onInboundTransfer(String ik, InboundTransferContext ctx) {
    if (!isOnChain(ctx)) {
        throw new InboundTransferRejection(409, "on-chain settlement missing");
    }
}
```

## Test plan
- [x] `mvn test` (all 155 tests pass)
- [x] 4 new tests in `InboundTransferRejectionTest` cover: typed reject → `RejectedPlan`; other exception → still `ApprovedPlan`; for both `onPlannedInboundTransfer` and `onInboundTransfer`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)