### PR TITLE
Bridge Ownera operator DB env vars to Spring Boot properties

### DIFF
--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessor.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessor.java
@@ -1,0 +1,230 @@
+package io.ownera.ledger.adapter.vanilla.spring;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.MutablePropertySources;
+import org.springframework.core.env.PropertySource;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Translates the Ownera operator's Go-adapter-style DB env-var contract into the
+ * Spring-Boot-native {@code spring.datasource.*} / {@code spring.flyway.*} properties that
+ * stock {@code DataSourceAutoConfiguration} expects. Lets a Java adapter deployed against the
+ * operator just work — no per-adapter property bridge.
+ *
+ * <h2>Contract</h2>
+ * <ul>
+ *   <li>{@code DB_CONNECTION_STRING} (fallback: {@code LEDGER_DB_CONNECTION_STRING}) —
+ *       {@code postgresql://user:pw@host:port/db?params} runtime connection.</li>
+ *   <li>{@code MIGRATION_CONNECTION_STRING} (fallback: {@code LEDGER_MIGRATION_CONNECTION_STRING})
+ *       — admin role used by Flyway.</li>
+ *   <li>{@code LEDGER_SCHEMA} (fallback: {@code LEDGER_SCHEMA_NAME}, default
+ *       {@value #DEFAULT_SCHEMA}) — schema that holds the ledger tables. Mapped to
+ *       {@code spring.flyway.default-schema}.</li>
+ *   <li>{@code LEDGER_DATASOURCE_SEARCH_PATH=true} (default off) — opt-in: inject a per-connection
+ *       {@code SET search_path TO &lt;schema&gt;, public} via Hikari's {@code connection-init-sql}.
+ *       Leave off for schema-qualified SQL.</li>
+ * </ul>
+ *
+ * <h2>Precedence</h2>
+ *
+ * <p>Runs as an {@link EnvironmentPostProcessor}, so it executes <em>before</em> Spring Boot's
+ * {@code application.yml} is loaded onto the {@code Environment}. Properties this EPP installs
+ * therefore win over yaml without any explicit check — but it still backs off when a
+ * higher-precedence source (command-line, system properties, system env exporting
+ * {@code SPRING_DATASOURCE_URL} directly) has already supplied the equivalent Spring property.
+ * This preserves manual overrides for test profiles, dev runs, and Testcontainers.
+ *
+ * <h2>Userinfo stripping</h2>
+ *
+ * <p>The Postgres JDBC driver does <strong>not</strong> parse {@code user:pw@host} from
+ * {@code jdbc:postgresql://} URLs — it treats the whole {@code user:pw@host} as the host and
+ * fails with {@code UnknownHostException}. Credentials are extracted into separate
+ * {@code spring.datasource.username} / {@code .password} and stripped from the URL before
+ * setting {@code spring.datasource.url}.
+ */
+public class DbUrlEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+    private static final Logger logger = LoggerFactory.getLogger(DbUrlEnvironmentPostProcessor.class);
+
+    public static final String DB_CONNECTION_STRING = "DB_CONNECTION_STRING";
+    public static final String LEGACY_DB_CONNECTION_STRING = "LEDGER_DB_CONNECTION_STRING";
+    public static final String MIGRATION_CONNECTION_STRING = "MIGRATION_CONNECTION_STRING";
+    public static final String LEGACY_MIGRATION_CONNECTION_STRING = "LEDGER_MIGRATION_CONNECTION_STRING";
+    public static final String LEDGER_SCHEMA = "LEDGER_SCHEMA";
+    public static final String LEGACY_LEDGER_SCHEMA = "LEDGER_SCHEMA_NAME";
+    public static final String DEFAULT_SCHEMA = "ledger_adapter";
+    public static final String ENABLE_SEARCH_PATH = "LEDGER_DATASOURCE_SEARCH_PATH";
+
+    static final String PROPERTY_SOURCE_NAME = "owneraDbConnectionBridge";
+
+    @Override
+    public void postProcessEnvironment(ConfigurableEnvironment env, SpringApplication app) {
+        Map<String, Object> derived = new HashMap<>();
+
+        // Runtime datasource.
+        String runtimeUrl = firstNonBlank(env.getProperty(DB_CONNECTION_STRING), env.getProperty(LEGACY_DB_CONNECTION_STRING));
+        if (runtimeUrl != null && !isOverriddenByHigherPrecedenceSource(env, "spring.datasource.url")) {
+            try {
+                Parsed parsed = parse(runtimeUrl);
+                derived.put("spring.datasource.url", parsed.jdbcUrl);
+                if (parsed.username != null) derived.put("spring.datasource.username", parsed.username);
+                if (parsed.password != null) derived.put("spring.datasource.password", parsed.password);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Failed to parse DB_CONNECTION_STRING; leaving spring.datasource.* untouched: {}", e.getMessage());
+            }
+        }
+
+        // Flyway migration datasource.
+        String migrationUrl = firstNonBlank(env.getProperty(MIGRATION_CONNECTION_STRING), env.getProperty(LEGACY_MIGRATION_CONNECTION_STRING));
+        if (migrationUrl != null && !isOverriddenByHigherPrecedenceSource(env, "spring.flyway.url")) {
+            try {
+                Parsed parsed = parse(migrationUrl);
+                derived.put("spring.flyway.url", parsed.jdbcUrl);
+                if (parsed.username != null) derived.put("spring.flyway.user", parsed.username);
+                if (parsed.password != null) derived.put("spring.flyway.password", parsed.password);
+            } catch (IllegalArgumentException e) {
+                logger.warn("Failed to parse MIGRATION_CONNECTION_STRING; leaving spring.flyway.* untouched: {}", e.getMessage());
+            }
+        }
+
+        // Schema → Flyway's default-schema (and optional runtime search_path).
+        // Only install when we've already installed a DB URL — otherwise this EPP would leak a
+        // schema setting into adapters that don't use a DB at all (the no-op case must stay
+        // truly no-op so vanilla-service stays compatible with bare / observer-mode deployments).
+        if (!derived.isEmpty()) {
+            String schema = firstNonBlank(env.getProperty(LEDGER_SCHEMA), env.getProperty(LEGACY_LEDGER_SCHEMA));
+            if (schema == null) schema = DEFAULT_SCHEMA;
+            if (!isOverriddenByHigherPrecedenceSource(env, "spring.flyway.default-schema")) {
+                derived.put("spring.flyway.default-schema", schema);
+            }
+            if (Boolean.parseBoolean(env.getProperty(ENABLE_SEARCH_PATH))
+                    && !isOverriddenByHigherPrecedenceSource(env, "spring.datasource.hikari.connection-init-sql")) {
+                derived.put("spring.datasource.hikari.connection-init-sql", "SET search_path TO " + schema + ", public");
+            }
+        }
+
+        if (derived.isEmpty()) {
+            return;
+        }
+
+        MutablePropertySources sources = env.getPropertySources();
+        sources.addFirst(new MapPropertySource(PROPERTY_SOURCE_NAME, derived));
+        logger.info("Installed {} property(s) from Ownera DB env-var bridge: {}", derived.size(), derived.keySet());
+    }
+
+    /**
+     * Parses {@code postgresql://user:pw@host:port/db?params} (with or without a leading
+     * {@code jdbc:}) into a JDBC URL plus extracted credentials.
+     */
+    static Parsed parse(String connectionString) {
+        String working = connectionString.startsWith("jdbc:") ? connectionString.substring(5) : connectionString;
+        URI uri;
+        try {
+            uri = new URI(working);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("Not a valid URI: " + redactedPreview(connectionString), e);
+        }
+
+        String username = null;
+        String password = null;
+        String userInfo = uri.getRawUserInfo();
+        if (userInfo != null && !userInfo.isEmpty()) {
+            int colon = userInfo.indexOf(':');
+            if (colon >= 0) {
+                username = decode(userInfo.substring(0, colon));
+                password = decode(userInfo.substring(colon + 1));
+            } else {
+                username = decode(userInfo);
+            }
+        }
+
+        String host = uri.getHost();
+        if (host == null) {
+            throw new IllegalArgumentException("Connection string is missing a host: " + redactedPreview(connectionString));
+        }
+        // Bracket IPv6 hosts when reconstructing; URI.getHost behaviour varies across JDK
+        // versions (sometimes returns the bracketed form, sometimes the bare address), so check
+        // before adding to avoid double-bracketing.
+        String hostForJdbc = (host.contains(":") && !host.startsWith("[")) ? "[" + host + "]" : host;
+
+        StringBuilder jdbc = new StringBuilder("jdbc:postgresql://").append(hostForJdbc);
+        if (uri.getPort() > 0) {
+            jdbc.append(':').append(uri.getPort());
+        }
+        if (uri.getRawPath() != null && !uri.getRawPath().isEmpty()) {
+            jdbc.append(uri.getRawPath());
+        }
+        if (uri.getRawQuery() != null && !uri.getRawQuery().isEmpty()) {
+            jdbc.append('?').append(uri.getRawQuery());
+        }
+        return new Parsed(jdbc.toString(), username, password);
+    }
+
+    /**
+     * Higher-precedence sources are command-line args, JVM system properties, and the OS
+     * environment (which is how an operator deployment would supply {@code SPRING_DATASOURCE_URL}
+     * directly, bypassing this bridge). {@code application.yml} and dynamically-added
+     * sources are loaded later — they don't count here, so this EPP wins over yaml.
+     */
+    private static boolean isOverriddenByHigherPrecedenceSource(ConfigurableEnvironment env, String key) {
+        for (PropertySource<?> source : env.getPropertySources()) {
+            if (isHigherPrecedence(source.getName()) && source.containsProperty(key)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isHigherPrecedence(String sourceName) {
+        // Spring Boot's well-known source names: systemProperties, systemEnvironment,
+        // commandLineArgs. Match defensively in case Spring renames them.
+        return sourceName != null
+                && (sourceName.contains("systemProperties")
+                || sourceName.contains("systemEnvironment")
+                || sourceName.contains("commandLine"));
+    }
+
+    private static String firstNonBlank(String... values) {
+        for (String v : values) {
+            if (v != null && !v.isEmpty()) return v;
+        }
+        return null;
+    }
+
+    private static String decode(String raw) {
+        return URLDecoder.decode(raw, StandardCharsets.UTF_8);
+    }
+
+    /** Redact userinfo before logging — credentials must not hit the logs even on parse failure. */
+    private static String redactedPreview(String connectionString) {
+        int at = connectionString.indexOf('@');
+        int slashSlash = connectionString.indexOf("//");
+        if (at > 0 && slashSlash > 0 && slashSlash < at) {
+            return connectionString.substring(0, slashSlash + 2) + "***@" + connectionString.substring(at + 1);
+        }
+        return connectionString;
+    }
+
+    static final class Parsed {
+        final String jdbcUrl;
+        final String username;
+        final String password;
+
+        Parsed(String jdbcUrl, String username, String password) {
+            this.jdbcUrl = jdbcUrl;
+            this.username = username;
+            this.password = password;
+        }
+    }
+}

--- a/vanilla-service/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
+++ b/vanilla-service/src/main/resources/META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
@@ -1,0 +1,1 @@
+io.ownera.ledger.adapter.vanilla.spring.DbUrlEnvironmentPostProcessor

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessorTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessorTest.java
@@ -1,0 +1,250 @@
+package io.ownera.ledger.adapter.vanilla.spring;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.core.env.MapPropertySource;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.env.SystemEnvironmentPropertySource;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Validates the Ownera operator → Spring Boot DB property bridge. Covers both the URL parser in
+ * isolation and the {@link DbUrlEnvironmentPostProcessor#postProcessEnvironment} end-to-end
+ * behaviour (back-off precedence, alias fallback, search-path opt-in, no-op on missing env).
+ */
+class DbUrlEnvironmentPostProcessorTest {
+
+    private final DbUrlEnvironmentPostProcessor epp = new DbUrlEnvironmentPostProcessor();
+
+    // ---- URL parser ----
+
+    @Test
+    void parseSplitsUserinfoOutOfTheJdbcUrl() {
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "postgresql://ledger:s3cret@db.example.com:5432/finp2p");
+        assertEquals("jdbc:postgresql://db.example.com:5432/finp2p", p.jdbcUrl);
+        assertEquals("ledger", p.username);
+        assertEquals("s3cret", p.password);
+    }
+
+    @Test
+    void parsePreservesQueryParamsVerbatim() {
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "postgresql://u:p@h:5432/d?sslmode=require&ApplicationName=swift-rails");
+        assertEquals("jdbc:postgresql://h:5432/d?sslmode=require&ApplicationName=swift-rails", p.jdbcUrl);
+    }
+
+    @Test
+    void parseHandlesUrlEncodedPassword() {
+        // operator may URL-encode special chars in the password (e.g. '@' → %40).
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "postgresql://user:p%40ss%21@host:5432/db");
+        assertEquals("user", p.username);
+        assertEquals("p@ss!", p.password);
+        assertFalse(p.jdbcUrl.contains("user:"), "userinfo must be stripped from the JDBC URL");
+    }
+
+    @Test
+    void parseHandlesUserWithoutPassword() {
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "postgresql://trusted-user@host:5432/db");
+        assertEquals("trusted-user", p.username);
+        assertNull(p.password);
+    }
+
+    @Test
+    void parseHandlesIpv6HostByReAddingBrackets() {
+        // URI.getHost strips brackets; we must reinsert them so the JDBC driver accepts the URL.
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "postgresql://u:p@[::1]:5432/db");
+        assertEquals("jdbc:postgresql://[::1]:5432/db", p.jdbcUrl);
+    }
+
+    @Test
+    void parseAcceptsAlreadyJdbcPrefixedInput() {
+        // Defensive: if someone hands us a jdbc-prefixed URL, don't double-prefix.
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "jdbc:postgresql://u:p@host:5432/db?sslmode=disable");
+        assertEquals("jdbc:postgresql://host:5432/db?sslmode=disable", p.jdbcUrl);
+        assertEquals("u", p.username);
+        assertEquals("p", p.password);
+    }
+
+    @Test
+    void parseTolaratesMissingPortAndDb() {
+        DbUrlEnvironmentPostProcessor.Parsed p = DbUrlEnvironmentPostProcessor.parse(
+                "postgresql://u:p@host");
+        assertEquals("jdbc:postgresql://host", p.jdbcUrl);
+    }
+
+    // ---- EPP end-to-end ----
+
+    @Test
+    void installsDatasourceAndFlywayPropertiesFromOperatorEnvVars() {
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://runtime:rpw@db:5432/finp2p?sslmode=require",
+                "MIGRATION_CONNECTION_STRING", "postgresql://admin:apw@db:5432/finp2p"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertEquals("jdbc:postgresql://db:5432/finp2p?sslmode=require", env.getProperty("spring.datasource.url"));
+        assertEquals("runtime", env.getProperty("spring.datasource.username"));
+        assertEquals("rpw", env.getProperty("spring.datasource.password"));
+        assertEquals("jdbc:postgresql://db:5432/finp2p", env.getProperty("spring.flyway.url"));
+        assertEquals("admin", env.getProperty("spring.flyway.user"));
+        assertEquals("apw", env.getProperty("spring.flyway.password"));
+        // Default schema applies when neither LEDGER_SCHEMA nor the legacy alias is set.
+        assertEquals(DbUrlEnvironmentPostProcessor.DEFAULT_SCHEMA, env.getProperty("spring.flyway.default-schema"));
+    }
+
+    @Test
+    void readsLegacyConnectionStringAliasWhenCanonicalNameIsUnset() {
+        // Older operator deployments and .env-based dev still use the LEDGER_-prefixed form.
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "LEDGER_DB_CONNECTION_STRING", "postgresql://u:p@host:5432/db",
+                "LEDGER_MIGRATION_CONNECTION_STRING", "postgresql://u:p@host:5432/db"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertEquals("jdbc:postgresql://host:5432/db", env.getProperty("spring.datasource.url"));
+        assertEquals("jdbc:postgresql://host:5432/db", env.getProperty("spring.flyway.url"));
+    }
+
+    @Test
+    void canonicalConnectionStringTakesPrecedenceOverLegacyAlias() {
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://canon:c@canon-host:5432/d",
+                "LEDGER_DB_CONNECTION_STRING", "postgresql://legacy:l@legacy-host:5432/d"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertEquals("jdbc:postgresql://canon-host:5432/d", env.getProperty("spring.datasource.url"));
+    }
+
+    @Test
+    void readsLedgerSchemaAndItsLegacyAlias() {
+        StandardEnvironment canonical = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://u:p@h:5432/d",
+                "LEDGER_SCHEMA", "canonical_schema"
+        )));
+        epp.postProcessEnvironment(canonical, null);
+        assertEquals("canonical_schema", canonical.getProperty("spring.flyway.default-schema"));
+
+        StandardEnvironment legacy = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://u:p@h:5432/d",
+                "LEDGER_SCHEMA_NAME", "swift_rails"
+        )));
+        epp.postProcessEnvironment(legacy, null);
+        assertEquals("swift_rails", legacy.getProperty("spring.flyway.default-schema"));
+    }
+
+    @Test
+    void searchPathInjectionIsOptInAndDefaultsOff() {
+        StandardEnvironment off = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://u:p@h:5432/d",
+                "LEDGER_SCHEMA", "my_schema"
+        )));
+        epp.postProcessEnvironment(off, null);
+        assertNull(off.getProperty("spring.datasource.hikari.connection-init-sql"),
+                "default-off: schema-qualified SQL doesn't need a search-path");
+
+        StandardEnvironment on = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://u:p@h:5432/d",
+                "LEDGER_SCHEMA", "my_schema",
+                "LEDGER_DATASOURCE_SEARCH_PATH", "true"
+        )));
+        epp.postProcessEnvironment(on, null);
+        assertEquals("SET search_path TO my_schema, public",
+                on.getProperty("spring.datasource.hikari.connection-init-sql"));
+    }
+
+    @Test
+    void backsOffWhenSpringDatasourceUrlIsAlreadyOnSystemEnv() {
+        // Equivalent of someone exporting SPRING_DATASOURCE_URL=... directly. Stock Spring
+        // autoconfig should handle it without our bridge.
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://bridge:bp@bridge-host:5432/d",
+                "SPRING_DATASOURCE_URL", "jdbc:postgresql://explicit-host:5432/d",
+                "SPRING_DATASOURCE_USERNAME", "explicit-user"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        // EPP leaves the explicit env value alone.
+        assertEquals("jdbc:postgresql://explicit-host:5432/d", env.getProperty("spring.datasource.url"));
+        assertEquals("explicit-user", env.getProperty("spring.datasource.username"));
+    }
+
+    @Test
+    void backsOffWhenSpringDatasourceUrlIsAlreadyOnSystemProperties() {
+        // -Dspring.datasource.url=... at JVM startup must beat the bridge.
+        Map<String, Object> sysProps = new HashMap<>();
+        sysProps.put("spring.datasource.url", "jdbc:postgresql://override-host:5432/d");
+
+        StandardEnvironment env = new StandardEnvironment();
+        env.getPropertySources().addFirst(new MapPropertySource("systemProperties", sysProps));
+        env.getPropertySources().addLast(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://bridge:bp@bridge-host:5432/d"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertEquals("jdbc:postgresql://override-host:5432/d", env.getProperty("spring.datasource.url"));
+    }
+
+    @Test
+    void noOpsGracefullyWhenNoConnectionEnvVarsAreSet() {
+        // Tests / Testcontainers / local dev with no operator-style env vars must not see this
+        // EPP install a half-baked property source. spring.datasource.* must remain absent.
+        StandardEnvironment env = environmentWith(systemEnv(Map.of()));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertNull(env.getProperty("spring.datasource.url"));
+        assertNull(env.getProperty("spring.datasource.username"));
+        assertNull(env.getProperty("spring.flyway.url"));
+        // Even spring.flyway.default-schema doesn't get installed without a DB connection — there
+        // is nothing for Flyway to migrate against.
+        assertFalse(env.getPropertySources().contains(DbUrlEnvironmentPostProcessor.PROPERTY_SOURCE_NAME));
+    }
+
+    @Test
+    void invalidConnectionStringWarnsAndLeavesPropertiesUnset() {
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "not a url at all"
+        )));
+
+        // Should not throw — parse failure is contained.
+        epp.postProcessEnvironment(env, null);
+
+        assertNull(env.getProperty("spring.datasource.url"),
+                "parse failure must leave spring.datasource.* untouched, not install garbage");
+    }
+
+    // ---- helpers ----
+
+    private static StandardEnvironment environmentWith(SystemEnvironmentPropertySource sysEnv) {
+        StandardEnvironment env = new StandardEnvironment();
+        // Replace the auto-discovered system env source (which would pollute the test with the
+        // host's real environment) with our controlled one.
+        env.getPropertySources().replace(StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME, sysEnv);
+        return env;
+    }
+
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private static SystemEnvironmentPropertySource systemEnv(Map<String, String> entries) {
+        Map<String, Object> copy = new HashMap<>(entries);
+        return new SystemEnvironmentPropertySource(
+                StandardEnvironment.SYSTEM_ENVIRONMENT_PROPERTY_SOURCE_NAME,
+                (Map) copy);
+    }
+}


### PR DESCRIPTION
## Summary

Every Java FinP2P adapter deployed against the Ownera operator has to translate the operator's Go-adapter-style `DB_CONNECTION_STRING=postgresql://user:pw@host:port/db` into Spring Boot's `spring.datasource.url=jdbc:postgresql://...` + `.username` + `.password` (plus the equivalent `spring.flyway.*` triple for the migration role) before stock `DataSourceAutoConfiguration` can pick it up. Without a shared bridge every adapter team ships their own near-identical `EnvironmentPostProcessor`.

This adds the bridge to `finp2p-java-vanilla-service`. That module is already the "I want the in-DB ledger" opt-in — pulling vanilla-service is by construction a Postgres deployment, so getting the operator-contract bridge for free is pure win. **Skeleton stays free of any DB-shaped assumptions** — observer-mode / limited-access adapters that don't depend on vanilla-service never see it.

## Covered

- `DB_CONNECTION_STRING` + `LEDGER_DB_CONNECTION_STRING` (legacy alias).
- `MIGRATION_CONNECTION_STRING` + `LEDGER_MIGRATION_CONNECTION_STRING` (legacy alias).
- `LEDGER_SCHEMA` canonical + `LEDGER_SCHEMA_NAME` legacy alias (default `ledger_adapter`) → `spring.flyway.default-schema`.
- `LEDGER_DATASOURCE_SEARCH_PATH=true` — opt-in per-connection `SET search_path` via Hikari `connection-init-sql`. Default **off** (schema-qualified SQL doesn't need one).
- Query-param preservation (`?sslmode=require`, `?currentSchema=...`, etc.).
- Userinfo stripping — the Postgres JDBC driver chokes on `user:pw@host` and fails with `UnknownHostException`; credentials are extracted into separate `.username` / `.password` and removed from the URL.
- URL-decoded credentials (handles `p%40ss%21` → `p@ss!`).
- IPv6 host re-bracketing across JDK variations.
- Back-off when higher-precedence sources (command-line, system properties, `SPRING_DATASOURCE_URL` exported on the env) already supply the equivalent property. `application.yml` does **not** count — EPP wins over yaml.
- Truly no-op when no env vars are set — keeps vanilla-service compatible with Testcontainers / dev runs that supply their own datasource.

Registered via `META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports`.

## Test plan
- [x] 16 focused tests in `DbUrlEnvironmentPostProcessorTest` cover the URL parser end-to-end (userinfo, query params, URL-encoded passwords, password-less form, IPv6, jdbc-prefix tolerance) and the EPP behaviour (env → spring properties, legacy aliases, schema mapping, opt-in search-path, back-off precedence, no-op on missing env, graceful warn-and-skip on malformed input).
- [x] `mvn test` — full reactor green (182 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)