### PR TITLE
Register DbUrlEnvironmentPostProcessor via spring.factories for Boot 2.7 consumers

### DIFF
--- a/vanilla-service/src/main/resources/META-INF/spring.factories
+++ b/vanilla-service/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,9 @@
+# EnvironmentPostProcessor registration for Spring Boot 2.7 consumers.
+#
+# Boot 3.0+ also reads META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports
+# (the modern discovery mechanism) — both files coexist intentionally so the EPP loads regardless
+# of whether the downstream adapter pulls Spring Boot 2.7 or 3.x. Boot 2.7's
+# EnvironmentPostProcessorApplicationListener reads exclusively from this file for this extension
+# point; .imports-style discovery on 2.7 only applies to AutoConfiguration.
+org.springframework.boot.env.EnvironmentPostProcessor=\
+io.ownera.ledger.adapter.vanilla.spring.DbUrlEnvironmentPostProcessor

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessorDiscoveryTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessorDiscoveryTest.java
@@ -1,0 +1,68 @@
+package io.ownera.ledger.adapter.vanilla.spring;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Properties;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Pins down EPP discovery registration. We ship <em>two</em> files because Spring Boot's
+ * {@code EnvironmentPostProcessor} extension point is read differently across versions:
+ *
+ * <ul>
+ *   <li>Boot 2.7 reads <em>only</em> {@code META-INF/spring.factories} for this extension point;
+ *       the {@code .imports}-style discovery doesn't apply.</li>
+ *   <li>Boot 3.x reads
+ *       {@code META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports}
+ *       (and tolerates {@code spring.factories} as a deprecated fallback).</li>
+ * </ul>
+ *
+ * <p>The 0.28.13 release shipped only the Boot-3 file, which silently broke EPP discovery on
+ * Boot 2.7 consumers (Hikari ended up with a null URL, no log line, no error). These tests
+ * fail loudly if either file goes missing or stops referencing the EPP — so the regression
+ * can't slip through again.
+ */
+class DbUrlEnvironmentPostProcessorDiscoveryTest {
+
+    private static final String EPP_FQN = "io.ownera.ledger.adapter.vanilla.spring.DbUrlEnvironmentPostProcessor";
+
+    @Test
+    void boot27DiscoveryViaSpringFactoriesIsRegistered() throws IOException {
+        URL resource = currentClassLoader().getResource("META-INF/spring.factories");
+        assertNotNull(resource, "META-INF/spring.factories must ship in the JAR — Boot 2.7 needs it");
+
+        Properties props = new Properties();
+        try (InputStream in = resource.openStream()) {
+            props.load(in);
+        }
+        String value = props.getProperty("org.springframework.boot.env.EnvironmentPostProcessor");
+        assertNotNull(value, "EnvironmentPostProcessor key missing in spring.factories");
+        assertTrue(value.contains(EPP_FQN),
+                "spring.factories must reference " + EPP_FQN + " — got: " + value);
+    }
+
+    @Test
+    void boot3DiscoveryViaImportsFileIsRegistered() throws IOException {
+        URL resource = currentClassLoader().getResource(
+                "META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports");
+        assertNotNull(resource, "Boot-3-style .imports file must ship in the JAR");
+
+        String contents;
+        try (InputStream in = resource.openStream()) {
+            contents = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        assertTrue(contents.contains(EPP_FQN),
+                ".imports file must reference " + EPP_FQN + " — got: " + contents);
+    }
+
+    private static ClassLoader currentClassLoader() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return cl != null ? cl : DbUrlEnvironmentPostProcessorDiscoveryTest.class.getClassLoader();
+    }
+}


### PR DESCRIPTION
## Summary

0.28.13 shipped EPP discovery only via the Spring Boot 3-style `.imports` file. Boot 2.7's `EnvironmentPostProcessorApplicationListener` reads **exclusively** from `META-INF/spring.factories` for this extension point — `.imports` discovery on 2.7 only covers `AutoConfiguration`.

Result for any Boot 2.7 consumer pulling vanilla-service 0.28.13: EPP never instantiated, `spring.datasource.url` never installed from `DB_CONNECTION_STRING`, Hikari fails with a null URL on first DB hit. No log line, no error — silent.

Reported by the SWIFT payment-rails team on Boot 2.7.18.

## Fix

Dual-registration:
- Keep `META-INF/spring/org.springframework.boot.env.EnvironmentPostProcessor.imports` for Boot 3+ (preferred mechanism).
- Add `META-INF/spring.factories` for Boot 2.7 (the only mechanism that version sees).

Both files coexist intentionally — Boot 3 reads both (treating `spring.factories` as a deprecated fallback) and Boot 2.7 only sees `spring.factories`.

## Regression guard

New `DbUrlEnvironmentPostProcessorDiscoveryTest` asserts that **both** files are on the classpath and reference the EPP FQN. Drop either, and CI fails loud — so the silent-discovery-miss can't repeat.

## Test plan
- [x] `mvn test` — 184 total (was 182, +2 discovery tests).
- [x] Existing 16 EPP behaviour tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)