### PR TITLE
Bridge runtime username into spring.flyway.placeholders.ledger_user

### DIFF
--- a/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessor.java
+++ b/vanilla-service/src/main/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessor.java
@@ -36,6 +36,17 @@ import java.util.Map;
  *       Leave off for schema-qualified SQL.</li>
  * </ul>
  *
+ * <h2>Runtime-role grant</h2>
+ *
+ * <p>The skeleton ships an {@code R__grant_ledger_user.sql} repeatable migration that grants
+ * schema + table privileges to the runtime role. The migration runs as the admin role (from
+ * {@code MIGRATION_CONNECTION_STRING}) and needs to know which runtime role to grant access to,
+ * via the Flyway placeholder {@code ${ledger_user}}. This EPP feeds the username extracted from
+ * {@code DB_CONNECTION_STRING} into {@code spring.flyway.placeholders.ledger_user} so the grant
+ * migration applies automatically — without this bridge the placeholder is empty, the migration
+ * is a silent no-op, and the runtime app gets {@code "permission denied for schema"} on first
+ * DB hit.
+ *
  * <h2>Precedence</h2>
  *
  * <p>Runs as an {@link EnvironmentPostProcessor}, so it executes <em>before</em> Spring Boot's
@@ -78,7 +89,18 @@ public class DbUrlEnvironmentPostProcessor implements EnvironmentPostProcessor {
             try {
                 Parsed parsed = parse(runtimeUrl);
                 derived.put("spring.datasource.url", parsed.jdbcUrl);
-                if (parsed.username != null) derived.put("spring.datasource.username", parsed.username);
+                if (parsed.username != null) {
+                    derived.put("spring.datasource.username", parsed.username);
+                    // Feed the runtime username into the Flyway placeholder consumed by the
+                    // skeleton's R__grant_ledger_user.sql. The grant migration runs as the
+                    // admin role (MIGRATION_CONNECTION_STRING) and needs to know which runtime
+                    // role to grant access to. Without this bridge the placeholder is empty,
+                    // the migration silently no-ops, and the runtime app gets "permission
+                    // denied for schema" on first DB hit.
+                    if (!isOverriddenByHigherPrecedenceSource(env, "spring.flyway.placeholders.ledger_user")) {
+                        derived.put("spring.flyway.placeholders.ledger_user", parsed.username);
+                    }
+                }
                 if (parsed.password != null) derived.put("spring.datasource.password", parsed.password);
             } catch (IllegalArgumentException e) {
                 logger.warn("Failed to parse DB_CONNECTION_STRING; leaving spring.datasource.* untouched: {}", e.getMessage());

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessorTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/spring/DbUrlEnvironmentPostProcessorTest.java
@@ -105,6 +105,55 @@ class DbUrlEnvironmentPostProcessorTest {
     }
 
     @Test
+    void bridgesRuntimeUsernameIntoFlywayLedgerUserPlaceholder() {
+        // The skeleton's R__grant_ledger_user.sql repeatable migration grants schema/table
+        // privileges to ${ledger_user}, which is sourced from spring.flyway.placeholders.ledger_user.
+        // Without this bridge the placeholder stays empty and the migration silently no-ops —
+        // runtime app then gets "permission denied for schema" on first DB hit.
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://ledger:rpw@db:5432/finp2p",
+                "MIGRATION_CONNECTION_STRING", "postgresql://migration:apw@db:5432/finp2p"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertEquals("ledger", env.getProperty("spring.datasource.username"));
+        assertEquals("ledger", env.getProperty("spring.flyway.placeholders.ledger_user"),
+                "runtime username must be mirrored into the Flyway placeholder feeding R__grant_ledger_user.sql");
+    }
+
+    @Test
+    void ledgerUserPlaceholderBacksOffWhenExplicitlyOverridden() {
+        // An adapter that wants the grant migration to target a different role than the
+        // runtime user (e.g. role-separation deployment with a shared GRANTed group) can
+        // override the placeholder explicitly — the bridge respects that.
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://ledger:rpw@db:5432/finp2p",
+                "SPRING_FLYWAY_PLACEHOLDERS_LEDGER_USER", "shared_readers"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertEquals("ledger", env.getProperty("spring.datasource.username"));
+        assertEquals("shared_readers", env.getProperty("spring.flyway.placeholders.ledger_user"));
+    }
+
+    @Test
+    void ledgerUserPlaceholderIsAbsentWhenConnectionStringHasNoUserinfo() {
+        // A trust-auth deployment may use a connection string with no embedded credentials.
+        // In that case there's no runtime username to bridge — the placeholder stays unset
+        // and the grant migration becomes a deliberate no-op rather than mis-targeting.
+        StandardEnvironment env = environmentWith(systemEnv(Map.of(
+                "DB_CONNECTION_STRING", "postgresql://db:5432/finp2p"
+        )));
+
+        epp.postProcessEnvironment(env, null);
+
+        assertNull(env.getProperty("spring.datasource.username"));
+        assertNull(env.getProperty("spring.flyway.placeholders.ledger_user"));
+    }
+
+    @Test
     void readsLegacyConnectionStringAliasWhenCanonicalNameIsUnset() {
         // Older operator deployments and .env-based dev still use the LEDGER_-prefixed form.
         StandardEnvironment env = environmentWith(systemEnv(Map.of(


### PR DESCRIPTION
## Summary

The skeleton ships an `R__grant_ledger_user.sql` repeatable migration that GRANTs schema/table privileges to a runtime role named by Flyway placeholder `${ledger_user}` (sourced from `spring.flyway.placeholders.ledger_user`). The EPP populated `spring.datasource.username` from `DB_CONNECTION_STRING` but didn't bridge that into the placeholder — so the placeholder stayed empty, the migration silently no-opped (per its `IF v_user <> ''` guard), and the runtime app got `permission denied for schema` on first DB hit.

Reported by the SWIFT payment-rails team running vanilla 0.28.14 on Boot 2.7.18.

## Fix

When the runtime URL is parsed and the username extracted, also install `spring.flyway.placeholders.ledger_user` with the same value. Subject to the same back-off semantics — an adapter that wants the grant migration to target a different role (e.g. a shared GRANTed group) can override the placeholder explicitly via `SPRING_FLYWAY_PLACEHOLDERS_LEDGER_USER=...`. Bridge is a no-op when the connection string carries no userinfo (trust-auth deployments).

## Test plan
- [x] 3 new tests in `DbUrlEnvironmentPostProcessorTest` cover the happy path (runtime username → placeholder), the explicit override (back-off preserves caller-supplied value), and the no-userinfo no-op (placeholder stays unset).
- [x] `mvn test` — 187 total, 0 failures (was 184, +3).
- [x] Class javadoc updated with a new "Runtime-role grant" section explaining the bridge contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)