### PR TITLE
Bump finp2p-java-sdk to 0.28.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <ownera.java.sdk.version>0.28.9</ownera.java.sdk.version>
+        <ownera.java.sdk.version>0.28.10</ownera.java.sdk.version>
         <jooq.version>3.19.7</jooq.version>
         <maven.deploy.skip>true</maven.deploy.skip>
     </properties>


### PR DESCRIPTION
## Summary
Picks up parsing-error fixes shipped in `finp2p-java-sdk` 0.28.10. No skeleton/vanilla/sample code changes needed.

## Test plan
- [x] `mvn test` — full reactor green (187 tests, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)