### PR TITLE
Grant sequence privileges to LEDGER_USER

### DIFF
--- a/skeleton/src/main/resources/db/migration/skeleton/R__grant_ledger_user.sql
+++ b/skeleton/src/main/resources/db/migration/skeleton/R__grant_ledger_user.sql
@@ -2,6 +2,12 @@
 -- Flyway placeholder ${ledger_user} is resolved from spring.flyway.placeholders.ledger_user.
 -- If the placeholder is empty, this migration is a no-op.
 -- Checks IF EXISTS to handle cases where schemas haven't been created yet.
+--
+-- Sequence grants (USAGE, SELECT, UPDATE) are required for inserts into tables backed by
+-- BIGSERIAL / SERIAL columns — without them the migration role owns the implicit sequence and
+-- the runtime role gets "permission denied for sequence <table>_id_seq" on the first INSERT.
+-- The ALTER DEFAULT PRIVILEGES variants apply the same grants to any future tables/sequences
+-- so the adapter doesn't need to re-run this migration after new DDL lands.
 
 DO
 $$
@@ -13,14 +19,18 @@ BEGIN
         IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = '${schema_name}') THEN
             EXECUTE format('GRANT USAGE ON SCHEMA ${schema_name} TO %I', v_user);
             EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ${schema_name} TO %I', v_user);
+            EXECUTE format('GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA ${schema_name} TO %I', v_user);
             EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema_name} GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', v_user);
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA ${schema_name} GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO %I', v_user);
         END IF;
 
         -- Adapter tables (public schema, where unqualified CREATE TABLE lands)
         IF EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = 'public') THEN
             EXECUTE format('GRANT USAGE ON SCHEMA public TO %I', v_user);
             EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO %I', v_user);
+            EXECUTE format('GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA public TO %I', v_user);
             EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO %I', v_user);
+            EXECUTE format('ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO %I', v_user);
         END IF;
     END IF;
 END

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaSeparateUsersGrantTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/vanilla/VanillaSeparateUsersGrantTest.java
@@ -1,0 +1,125 @@
+package io.ownera.ledger.adapter.vanilla;
+
+import org.flywaydb.core.Flyway;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.postgresql.ds.PGSimpleDataSource;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+/**
+ * Verifies that the skeleton's {@code R__grant_ledger_user.sql} repeatable migration grants
+ * <em>sequence</em> privileges in addition to table privileges, so a separate runtime role can
+ * INSERT into vanilla-service's {@code accounts} table (which has a {@code BIGSERIAL} id column,
+ * backed by an implicit sequence).
+ *
+ * <p>Without the sequence grant, the runtime role's first INSERT fails with
+ * {@code permission denied for sequence accounts_id_seq}. The existing {@code AbstractBusinessLogicTest}
+ * sub-classes in sample-adapter don't catch this because sample-adapter doesn't depend on
+ * vanilla-service and therefore doesn't have any BIGSERIAL-backed tables. This test plugs that
+ * gap in CI so the regression can't repeat silently.
+ *
+ * <p>Reuses the shared Testcontainers Postgres from {@link VanillaPostgresHolder} so the
+ * container start cost is amortised across the suite, but installs everything (migrations,
+ * runtime role, separate schema) inside an isolated namespace to avoid colliding with the
+ * holder's existing fixtures.
+ */
+class VanillaSeparateUsersGrantTest {
+
+    private static final String SCHEMA = "vanilla_separate_users_test";
+    private static final String RUNTIME_USER = "vanilla_separate_users_runtime";
+    private static final String RUNTIME_PASSWORD = "runtime-pw";
+
+    @BeforeAll
+    static void prepareSeparateUserDeployment() throws SQLException {
+        // The shared container is started by VanillaPostgresHolder; reference it so JUnit's
+        // ordering doesn't matter — touching the field forces class-init, which boots the
+        // container if it isn't already up.
+        VanillaPostgresHolder.POSTGRES.getJdbcUrl();
+
+        try (Connection admin = adminDataSource().getConnection();
+             Statement stmt = admin.createStatement()) {
+            // Tear down any leftover state from a previous run so the migration's
+            // CREATE-IF-NOT-EXISTS / ALTER DEFAULT PRIVILEGES paths exercise the
+            // create-new-everything code-path each time.
+            stmt.execute("DROP SCHEMA IF EXISTS " + SCHEMA + " CASCADE");
+            stmt.execute("DROP ROLE IF EXISTS " + RUNTIME_USER);
+
+            stmt.execute("CREATE ROLE " + RUNTIME_USER
+                    + " WITH LOGIN PASSWORD '" + RUNTIME_PASSWORD + "'");
+        }
+
+        // Run the migrations as the admin user, telling the grant migration which role to grant.
+        Map<String, String> placeholders = new HashMap<>();
+        placeholders.put("schema_name", SCHEMA);
+        placeholders.put("ledger_user", RUNTIME_USER);
+        Flyway.configure()
+                .dataSource(adminDataSource())
+                .locations("classpath:db/migration/skeleton", "classpath:db/migration/vanilla")
+                .placeholders(placeholders)
+                .schemas(SCHEMA)
+                .createSchemas(true)
+                .load()
+                .migrate();
+    }
+
+    @Test
+    void runtimeUserCanInsertIntoBigserialBackedAccountsTable() throws SQLException {
+        // Connect as the runtime role and execute an INSERT that exercises the implicit
+        // accounts_id_seq sequence. Without sequence-level USAGE on the runtime role this
+        // throws PSQLException("permission denied for sequence accounts_id_seq") — which is
+        // exactly the production failure reported by SWIFT on 0.28.16.
+        PGSimpleDataSource runtimeDs = runtimeDataSource();
+        try (Connection conn = runtimeDs.getConnection();
+             Statement stmt = conn.createStatement()) {
+            assertDoesNotThrow(() ->
+                    stmt.executeUpdate(
+                            "INSERT INTO " + SCHEMA + ".accounts (fin_id, asset_id, asset_type) "
+                                    + "VALUES ('fin-regression', 'asset-regression', 'finp2p')"),
+                    "Runtime user must be granted sequence USAGE for INSERTs against the "
+                            + "BIGSERIAL accounts.id column to succeed");
+        }
+    }
+
+    @Test
+    void runtimeUserCanInsertIntoAccountsCreatedAfterGrantMigration() throws SQLException {
+        // ALTER DEFAULT PRIVILEGES protects future tables/sequences. Create a brand-new
+        // BIGSERIAL-backed table as the admin role and verify the runtime user can INSERT
+        // without the grant migration needing to re-run. This is what keeps the adapter from
+        // having to bounce the grant migration after every new DDL.
+        try (Connection admin = adminDataSource().getConnection();
+             Statement stmt = admin.createStatement()) {
+            stmt.execute("CREATE TABLE " + SCHEMA + ".future_table (id BIGSERIAL PRIMARY KEY, label TEXT)");
+        }
+
+        try (Connection conn = runtimeDataSource().getConnection();
+             Statement stmt = conn.createStatement()) {
+            assertDoesNotThrow(() ->
+                    stmt.executeUpdate("INSERT INTO " + SCHEMA + ".future_table (label) VALUES ('regression')"),
+                    "ALTER DEFAULT PRIVILEGES must extend sequence USAGE to tables created after "
+                            + "the grant migration ran");
+        }
+    }
+
+    private static PGSimpleDataSource adminDataSource() {
+        PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setUrl(VanillaPostgresHolder.POSTGRES.getJdbcUrl());
+        ds.setUser(VanillaPostgresHolder.POSTGRES.getUsername());
+        ds.setPassword(VanillaPostgresHolder.POSTGRES.getPassword());
+        return ds;
+    }
+
+    private static PGSimpleDataSource runtimeDataSource() {
+        PGSimpleDataSource ds = new PGSimpleDataSource();
+        ds.setUrl(VanillaPostgresHolder.POSTGRES.getJdbcUrl());
+        ds.setUser(RUNTIME_USER);
+        ds.setPassword(RUNTIME_PASSWORD);
+        return ds;
+    }
+}


### PR DESCRIPTION
## Summary

vanilla-service's `accounts` table uses a `BIGSERIAL id` column backed by an implicit `accounts_id_seq` sequence. `R__grant_ledger_user.sql` granted table-level privileges but never granted sequence `USAGE`/`SELECT`/`UPDATE`, so a separate runtime role (the operator's two-user deployment pattern) couldn't INSERT into `accounts` — first INSERT failed with:

```
ERROR: permission denied for sequence accounts_id_seq
```

`PostgresSeparateUsersTest` in sample-adapter didn't catch this because sample-adapter doesn't depend on vanilla-service and has no BIGSERIAL-backed tables. SWIFT payment-rails hit this in production on vanilla 0.28.16.

## Fix

- `GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA <schema> TO <ledger_user>` — for existing sequences.
- `ALTER DEFAULT PRIVILEGES IN SCHEMA <schema> GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO <ledger_user>` — for any future sequences created by adapter migrations later, so the grant migration stays idempotent rather than needing to re-run on every DDL change.
- Same dual-schema treatment (`${schema_name}` + `public`) as the existing table grants.

## Regression test

New `VanillaSeparateUsersGrantTest` in vanilla-service exercises the exact failing path:

1. Creates a separate runtime role on the shared Testcontainers Postgres.
2. Runs all skeleton + vanilla migrations as the admin role, with the `ledger_user` placeholder set.
3. Connects as the runtime role and INSERTs into the BIGSERIAL-backed `accounts` table.
4. Also creates a fresh `BIGSERIAL`-backed table *after* the grant migration runs and asserts the runtime role can still INSERT — covering the `ALTER DEFAULT PRIVILEGES` path.

**Verified that both assertions reproduce the SWIFT-reported `PSQLException("permission denied for sequence ...")` when the migration is reverted, and pass with the fix.**

## Test plan
- [x] `mvn test` — full reactor green (189 tests, +2 new regression tests).
- [x] Manual revert + re-run confirmed both new tests fail without the migration change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)