### PR TITLE
AssetStore: add getByTokenId / existsByTokenId

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/asset/AssetStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/asset/AssetStore.java
@@ -7,7 +7,12 @@ import javax.annotation.Nullable;
 /**
  * Persistence contract for the skeleton-owned {@code ledger_adapter.assets} table.
  * Adapters can persist an {@link Asset} (including its {@link io.ownera.ledger.adapter.service.model.LedgerAssetIdentifier})
- * during {@code createAsset} and look it up later via {@link #getById}.
+ * during {@code createAsset} and look it up later — either by FinP2P {@code assetId} (the
+ * primary key) or by the ledger-side {@code tokenId} (the on-chain handle the asset is bound
+ * to). The latter is the lookup adapters need when {@code createAsset} receives an
+ * {@code AssetBind} with a pre-existing {@code tokenIdentifier.tokenId} and the adapter wants
+ * to confirm the bound asset is actually registered locally rather than blindly echoing the
+ * tokenId back.
  */
 public interface AssetStore {
 
@@ -26,4 +31,26 @@ public interface AssetStore {
      * @return {@code true} if the asset is registered, {@code false} otherwise.
      */
     boolean exists(String assetId);
+
+    /**
+     * Look up an asset by the ledger-side {@code tokenId} carried on its
+     * {@link io.ownera.ledger.adapter.service.model.LedgerAssetIdentifier}.
+     *
+     * <p>Returns {@code null} when no row matches — this is the signal adapters should treat
+     * as "the bound asset isn't registered here" during {@code createAsset}.
+     *
+     * <p>A blank {@code tokenId} matches the empty-string backfill rows written by 0.27.x →
+     * 0.28 migration and is treated as a miss (returns {@code null}). Callers should never
+     * pass an empty string deliberately.
+     *
+     * @param tokenId non-null, non-empty ledger-side token id; nulls / empty strings return null.
+     * @return the persisted asset, or {@code null} if no row matches.
+     */
+    @Nullable
+    Asset getByTokenId(String tokenId);
+
+    /**
+     * @return {@code true} if any registered asset is bound to {@code tokenId}.
+     */
+    boolean existsByTokenId(String tokenId);
 }

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/asset/DbAssetStore.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/asset/DbAssetStore.java
@@ -6,8 +6,11 @@ import io.ownera.ledger.adapter.service.model.LedgerAssetIdentifier;
 import org.jooq.DSLContext;
 import org.jooq.Field;
 import org.jooq.Record;
+import org.jooq.Result;
 import org.jooq.Table;
 import org.jooq.impl.DSL;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Database-backed {@link AssetStore}.
@@ -15,6 +18,8 @@ import org.jooq.impl.DSL;
  * Uses jOOQ plain DSL (no codegen) so the skeleton stays self-contained.
  */
 public class DbAssetStore implements AssetStore {
+
+    private static final Logger logger = LoggerFactory.getLogger(DbAssetStore.class);
 
     private static final Field<String> TYPE = DSL.field(DSL.name("type"), String.class);
     private static final Field<String> ID = DSL.field(DSL.name("id"), String.class);
@@ -74,5 +79,46 @@ public class DbAssetStore implements AssetStore {
     @Override
     public boolean exists(String assetId) {
         return dsl.fetchCount(table, ID.eq(assetId)) > 0;
+    }
+
+    @Override
+    public Asset getByTokenId(String tokenId) {
+        if (tokenId == null || tokenId.isEmpty()) {
+            // Treat blank as a miss: the 0.27.x → 0.28 backfill inserted empty strings into
+            // existing rows, and we don't want a blank lookup to coincidentally surface those.
+            return null;
+        }
+        // V1003 added a partial index on token_id (WHERE token_id <> ''), so this should hit
+        // the index. token_id is not declared unique at the DB layer; if the adapter has ever
+        // double-bound the same on-chain token to two FinP2P assetIds (a data error), pick
+        // the first match and warn-log — better than silently failing and better than
+        // throwing in the hot path.
+        Result<? extends Record> rows = dsl.select(TYPE, ID, TOKEN_STANDARD, TOKEN_ID, NETWORK)
+                .from(table)
+                .where(TOKEN_ID.eq(tokenId))
+                .limit(2)
+                .fetch();
+        if (rows.isEmpty()) {
+            return null;
+        }
+        if (rows.size() > 1) {
+            logger.warn("Multiple assets registered with token_id={} — returning first match. "
+                    + "This is a data error; investigate.", tokenId);
+        }
+        Record row = rows.get(0);
+        AssetType type = AssetType.valueOf(row.get(TYPE));
+        String storedTokenId = row.get(TOKEN_ID);
+        String network = row.get(NETWORK);
+        String standard = row.get(TOKEN_STANDARD);
+        LedgerAssetIdentifier ledgerId = (storedTokenId != null && !storedTokenId.isEmpty())
+                ? new LedgerAssetIdentifier(network, storedTokenId, standard)
+                : null;
+        return new Asset(row.get(ID), type, ledgerId);
+    }
+
+    @Override
+    public boolean existsByTokenId(String tokenId) {
+        if (tokenId == null || tokenId.isEmpty()) return false;
+        return dsl.fetchCount(table, TOKEN_ID.eq(tokenId)) > 0;
     }
 }

--- a/skeleton/src/main/resources/db/migration/skeleton/V1004__index_assets_token_id.sql
+++ b/skeleton/src/main/resources/db/migration/skeleton/V1004__index_assets_token_id.sql
@@ -1,0 +1,15 @@
+-- Index ledger_adapter.assets.token_id for AssetStore.getByTokenId / existsByTokenId.
+--
+-- Adapters that honor AssetBind during createAsset need to look up an asset by its on-chain
+-- tokenId to confirm it's registered locally (rather than silently echoing the supplied
+-- tokenId back into a fresh SuccessfulAssetCreation). Without an index the lookup is a full
+-- table scan over the assets table, which is small today but grows linearly with every
+-- create_asset call.
+--
+-- Partial WHERE token_id <> '' excludes the empty-string backfill rows that V1002 left in
+-- existing 0.27.x → 0.28 upgrades. Those rows aren't bound to any on-chain token and
+-- shouldn't be returned by a tokenId lookup anyway.
+
+CREATE INDEX IF NOT EXISTS assets_token_id_idx
+    ON ${schema_name}.assets (token_id)
+    WHERE token_id <> '';

--- a/vanilla-service/src/test/java/io/ownera/ledger/adapter/service/asset/DbAssetStoreTest.java
+++ b/vanilla-service/src/test/java/io/ownera/ledger/adapter/service/asset/DbAssetStoreTest.java
@@ -1,0 +1,104 @@
+package io.ownera.ledger.adapter.service.asset;
+
+import io.ownera.ledger.adapter.service.model.Asset;
+import io.ownera.ledger.adapter.service.model.AssetType;
+import io.ownera.ledger.adapter.service.model.LedgerAssetIdentifier;
+import io.ownera.ledger.adapter.vanilla.VanillaPostgresHolder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Exercises {@link DbAssetStore} against the shared Testcontainers Postgres (via
+ * {@link VanillaPostgresHolder}). The skeleton itself is DB-free at test scope, so the
+ * Postgres integration tests live in vanilla-service.
+ *
+ * <p>Focus is the new {@code getByTokenId} / {@code existsByTokenId} lookup added so adapters
+ * honouring {@code AssetBind} during {@code createAsset} can confirm the bound asset is
+ * actually registered locally rather than blindly echoing the supplied tokenId back.
+ */
+class DbAssetStoreTest {
+
+    private final DbAssetStore store = new DbAssetStore(VanillaPostgresHolder.CTX, VanillaPostgresHolder.SCHEMA);
+
+    @Test
+    void savedAssetIsRetrievableByTokenId() {
+        String assetId = "asset-tokid-" + System.nanoTime();
+        String tokenId = "0xtoken-" + System.nanoTime();
+        store.save(new Asset(assetId, AssetType.FINP2P,
+                new LedgerAssetIdentifier("eip155:1", tokenId, "ERC-20")));
+
+        Asset found = store.getByTokenId(tokenId);
+        assertNotNull(found, "asset must be retrievable by the on-chain tokenId it was saved with");
+        assertEquals(assetId, found.assetId);
+        assertEquals(AssetType.FINP2P, found.assetType);
+        assertNotNull(found.ledgerIdentifier);
+        assertEquals(tokenId, found.ledgerIdentifier.tokenId);
+        assertEquals("eip155:1", found.ledgerIdentifier.network);
+        assertEquals("ERC-20", found.ledgerIdentifier.standard);
+    }
+
+    @Test
+    void existsByTokenIdMirrorsGetByTokenId() {
+        String tokenId = "0xtoken-exists-" + System.nanoTime();
+        assertFalse(store.existsByTokenId(tokenId), "fresh tokenId must not exist");
+
+        store.save(new Asset("asset-" + System.nanoTime(), AssetType.FINP2P,
+                new LedgerAssetIdentifier("net", tokenId, "std")));
+        assertTrue(store.existsByTokenId(tokenId), "tokenId must surface after save");
+    }
+
+    @Test
+    void unknownTokenIdReturnsNullAndFalse() {
+        // A tokenId no one ever saved must yield a clean miss — that's the signal adapters use
+        // to reject AssetBind references to unregistered assets.
+        String tokenId = "never-registered-" + System.nanoTime();
+        assertNull(store.getByTokenId(tokenId));
+        assertFalse(store.existsByTokenId(tokenId));
+    }
+
+    @Test
+    void blankTokenIdIsAlwaysAMiss() {
+        // The 0.27.x → 0.28 migration backfills existing rows with token_id=''.  We must NOT
+        // surface those rows when a caller passes a blank tokenId — that would conflate
+        // "unbound legacy row" with "registered asset".  Both null and the empty string are
+        // treated as a miss.
+        assertNull(store.getByTokenId(null));
+        assertNull(store.getByTokenId(""));
+        assertFalse(store.existsByTokenId(null));
+        assertFalse(store.existsByTokenId(""));
+    }
+
+    @Test
+    void duplicateTokenIdReturnsOneOfTheMatchesWithoutThrowing() {
+        // token_id is not declared UNIQUE at the DB layer (the PK is (type, id)), so an adapter
+        // bug could theoretically bind the same on-chain token to two FinP2P assetIds.  The
+        // lookup must degrade gracefully — pick one, log loudly, don't throw in the hot path.
+        String sharedTokenId = "0xdup-" + System.nanoTime();
+        String firstAssetId = "asset-A-" + System.nanoTime();
+        String secondAssetId = "asset-B-" + System.nanoTime();
+        store.save(new Asset(firstAssetId, AssetType.FINP2P,
+                new LedgerAssetIdentifier("net", sharedTokenId, "std")));
+        store.save(new Asset(secondAssetId, AssetType.FINP2P,
+                new LedgerAssetIdentifier("net", sharedTokenId, "std")));
+
+        Asset found = store.getByTokenId(sharedTokenId);
+        assertNotNull(found);
+        assertTrue(found.assetId.equals(firstAssetId) || found.assetId.equals(secondAssetId),
+                "must return one of the duplicated rows, not throw; got " + found.assetId);
+    }
+
+    @Test
+    void backCompatGetByIdStillWorksAfterTokenIdAdditions() {
+        // Sanity: the new lookup paths can't have regressed the existing primary-key lookup.
+        String assetId = "asset-backcompat-" + System.nanoTime();
+        store.save(new Asset(assetId, AssetType.FINP2P,
+                new LedgerAssetIdentifier("net", "tok-" + System.nanoTime(), "std")));
+        assertTrue(store.exists(assetId));
+        assertNotNull(store.getById(assetId));
+    }
+}


### PR DESCRIPTION
## Summary

Adapters that honour `AssetBind` during `TokenService.createAsset` had no way to confirm the bound asset was actually registered locally — `AssetStore` only exposed lookup by FinP2P `assetId`. Adapters either copied `DbAssetStore` or trusted the router blindly.

This PR adds two lookup methods to the `AssetStore` contract:

```java
@Nullable Asset getByTokenId(String tokenId);
boolean        existsByTokenId(String tokenId);
```

`DbAssetStore` impl uses jOOQ. `token_id` isn't `UNIQUE` at the DB layer (PK is `(type, id)`), so the lookup degrades gracefully on the data-error case where the same on-chain token was bound to multiple FinP2P `assetId`s: pick the first match, warn-log, never throw.

### Migration

`V1004__index_assets_token_id.sql` adds a partial index:

```sql
CREATE INDEX IF NOT EXISTS assets_token_id_idx
    ON ${schema_name}.assets (token_id)
    WHERE token_id <> '';
```

The partial `WHERE` excludes empty-string backfill rows that V1002 left in 0.27.x → 0.28 upgrades — those aren't bound to anything and shouldn't surface from a tokenId lookup. Blank inputs (`null`, `""`) to both new methods are treated as misses for the same reason.

### Out of scope

Wiring this into `VanillaServiceImpl.createAsset` would convert today's silent-echo behaviour into a fail-closed reject — that's a behaviour change I'm leaving for adapters to opt into rather than flipping for everyone in a patch release.

### Test plan
- [x] 6 new tests in `DbAssetStoreTest` (vanilla-service test scope, since skeleton itself is DB-free):
  - saved asset is retrievable by tokenId
  - `existsByTokenId` mirrors `getByTokenId`
  - unknown tokenId returns `null` / `false`
  - blank tokenId is always a miss (covers the 0.27 backfill case)
  - duplicate tokenId returns one match without throwing
  - back-compat: `getById` / `exists` still work after the additions
- [x] `mvn test` — full reactor green (204 tests, +6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)