### PR TITLE
InboundTransferHook: canonical planId + receipt from completion event

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
@@ -9,8 +9,12 @@ import io.ownera.finp2p.opapi.model.ExecutionPlanOperation;
 import io.ownera.finp2p.opapi.model.Finp2pAsset;
 import io.ownera.finp2p.opapi.model.Finp2pAssetAccount;
 import io.ownera.finp2p.opapi.model.HoldInstruction;
+import io.ownera.finp2p.opapi.model.InstructionCompletionError;
+import io.ownera.finp2p.opapi.model.InstructionCompletionEvent;
+import io.ownera.finp2p.opapi.model.InstructionCompletionEventOutput;
 import io.ownera.finp2p.opapi.model.IssueInstruction;
 import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
+import io.ownera.finp2p.opapi.model.ReceiptOutput;
 import io.ownera.finp2p.opapi.model.RedemptionInstruction;
 import io.ownera.finp2p.opapi.model.TransferInstruction;
 import io.ownera.ledger.adapter.service.PlanApprovalService;
@@ -146,6 +150,14 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
             return new ApprovedPlan();
         }
 
+        // Prefer the plan's own id over the proposal envelope's id. They are usually the same
+        // value the router echoes back, but when an adapter sees a 64-char hex in the wire
+        // proposal that doesn't match a router-known plan id, falling back to plan.getId()
+        // gives the hook the canonical handle for downstream lookups (getReceipt, etc.).
+        String canonicalPlanId = plan.getId() != null && !plan.getId().isEmpty()
+                ? plan.getId()
+                : planId;
+
         for (ExecutionInstruction instr : plan.getInstructions()) {
             if (instr.getSequence() != null && instr.getSequence() == instructionSequence) {
                 ExecutionPlanOperation op = instr.getExecutionPlanOperation();
@@ -160,16 +172,20 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
                             ? transfer.getDestination()
                             : transfer.getSource());
 
+                    InstructionCompletionEvent event = findCompletionEvent(execution, instructionSequence);
+                    InboundTransferHook.InstructionResult result = toInstructionResult(event);
+                    InboundTransferHook.InstructionReceipt receipt = toInstructionReceipt(event);
+
                     try {
                         inboundTransferHook.onInboundTransfer(idempotencyKey,
                                 new InboundTransferHook.InboundTransferContext(
-                                        planId, srcFinId,
+                                        canonicalPlanId, srcFinId,
                                         asset,
                                         destFinId, transfer.getAmount(),
-                                        instructionSequence, null));
+                                        instructionSequence, result, receipt));
                     } catch (InboundTransferRejection r) {
                         logger.info("Inbound transfer rejected by hook: plan={}, seq={}, code={}, msg={}",
-                                planId, instructionSequence, r.getCode(), r.getMessage());
+                                canonicalPlanId, instructionSequence, r.getCode(), r.getMessage());
                         return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
                     } catch (Exception e) {
                         logger.warn("Inbound transfer hook failed: {}", e.getMessage());
@@ -180,6 +196,77 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
         }
 
         return new ApprovedPlan();
+    }
+
+    /**
+     * Pull the completion event for {@code instructionSequence} out of {@code execution}. The
+     * router populates {@code instructionsCompletionEvents} only after the instruction has
+     * actually completed on the underlying ledger; returns {@code null} if the event hasn't
+     * landed yet (proposal arrived ahead of completion, which is the common race).
+     */
+    private static @Nullable InstructionCompletionEvent findCompletionEvent(Execution execution, int instructionSequence) {
+        if (execution.getInstructionsCompletionEvents() == null) return null;
+        for (InstructionCompletionEvent event : execution.getInstructionsCompletionEvents()) {
+            if (event.getInstructionSequenceNumber() != null
+                    && event.getInstructionSequenceNumber() == instructionSequence) {
+                return event;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Map the router-side {@code InstructionCompletionEvent} into the framework-native
+     * {@link InboundTransferHook.InstructionResult} summary (transaction id + error code +
+     * error message). Either branch of the {@code InstructionCompletionEventOutput} oneOf
+     * collapses to a flat result here; {@code null} returns surface as "no completion yet".
+     */
+    private static @Nullable InboundTransferHook.InstructionResult toInstructionResult(@Nullable InstructionCompletionEvent event) {
+        if (event == null) return null;
+        InstructionCompletionEventOutput output = event.getOutput();
+        if (output == null) return null;
+        Object actual = output.getActualInstance();
+        if (actual instanceof ReceiptOutput) {
+            ReceiptOutput receipt = (ReceiptOutput) actual;
+            return InboundTransferHook.InstructionResult.receipt(receipt.getId());
+        }
+        if (actual instanceof InstructionCompletionError) {
+            InstructionCompletionError error = (InstructionCompletionError) actual;
+            int code = error.getCode() != null ? error.getCode() : 0;
+            return InboundTransferHook.InstructionResult.error(code, error.getMessage());
+        }
+        return null;
+    }
+
+    /**
+     * Map the receipt branch of a {@code InstructionCompletionEventOutput} into the
+     * framework-native {@link InboundTransferHook.InstructionReceipt}. Returns {@code null}
+     * for error branches and when no event is attached — adapters use this to look up the
+     * full receipt downstream via {@code FinP2PSDK.getReceipt(transactionId)}.
+     */
+    private static @Nullable InboundTransferHook.InstructionReceipt toInstructionReceipt(@Nullable InstructionCompletionEvent event) {
+        if (event == null) return null;
+        InstructionCompletionEventOutput output = event.getOutput();
+        if (output == null) return null;
+        Object actual = output.getActualInstance();
+        if (!(actual instanceof ReceiptOutput)) return null;
+        ReceiptOutput receipt = (ReceiptOutput) actual;
+        String operationType = receipt.getOperationType() != null
+                ? receipt.getOperationType().getValue()
+                : null;
+        String sourceFinId = finIdOf(receipt.getSource());
+        String destinationFinId = finIdOf(receipt.getDestination());
+        return new InboundTransferHook.InstructionReceipt(
+                receipt.getId(),
+                operationType,
+                sourceFinId,
+                destinationFinId,
+                receipt.getQuantity());
+    }
+
+    private static @Nullable String finIdOf(@Nullable Finp2pAssetAccount account) {
+        if (account == null || account.getAccount() == null) return null;
+        return account.getAccount().getFinId();
     }
 
     @Override

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferHook.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferHook.java
@@ -23,6 +23,13 @@ public interface InboundTransferHook {
     /**
      * Called after an instruction-level proposal is executed for an inbound transfer. Throw
      * {@link InboundTransferRejection} to reject the proposal.
+     *
+     * <p>{@code ctx.receipt} carries the router-side instruction completion (transaction id +
+     * operation metadata) when the corresponding {@code instructionsCompletionEvents} entry
+     * was a {@code ReceiptOutput}; {@code ctx.result} mirrors the same value in the legacy
+     * receipt/error summary shape. Both may be {@code null} if the router hasn't reported a
+     * completion event yet — adapters should treat that as "not ready" rather than "no
+     * receipt".
      */
     void onInboundTransfer(String idempotencyKey, InboundTransferContext ctx);
 
@@ -45,12 +52,55 @@ public interface InboundTransferHook {
     class InboundTransferContext extends PlannedInboundTransferContext {
         public final int instructionSequence;
         public final @Nullable InstructionResult result;
+        public final @Nullable InstructionReceipt receipt;
+
+        /**
+         * Back-compat constructor — no router-side completion event attached. Existing call
+         * sites continue to compile; new sites should use the {@code receipt}-aware overload
+         * below so adapters can read the {@code transactionId}, source/destination finIds, and
+         * operation type without a separate {@code getReceipt} round-trip.
+         */
+        public InboundTransferContext(String planId, String source, Asset asset, String destination, String amount,
+                                      int instructionSequence, @Nullable InstructionResult result) {
+            this(planId, source, asset, destination, amount, instructionSequence, result, null);
+        }
 
         public InboundTransferContext(String planId, String source, Asset asset, String destination, String amount,
-                                     int instructionSequence, @Nullable InstructionResult result) {
+                                      int instructionSequence,
+                                      @Nullable InstructionResult result,
+                                      @Nullable InstructionReceipt receipt) {
             super(planId, source, asset, destination, amount);
             this.instructionSequence = instructionSequence;
             this.result = result;
+            this.receipt = receipt;
+        }
+    }
+
+    /**
+     * Lightweight receipt summary surfaced to {@link #onInboundTransfer}, derived from the
+     * router's {@code instructionsCompletionEvents} entry for this instruction. Adapters that
+     * need more than what's modelled here can use {@code transactionId} to look the full
+     * receipt up via {@code FinP2PSDK.getReceipt(...)} — that's the canonical handle
+     * on the router side.
+     */
+    class InstructionReceipt {
+        /** Router-side receipt id (== local {@code transactionId}). */
+        public final String transactionId;
+        /** Operation type as reported by the router (e.g. {@code "issue"}, {@code "transfer"}). */
+        public final String operationType;
+        public final @Nullable String sourceFinId;
+        public final @Nullable String destinationFinId;
+        public final String quantity;
+
+        public InstructionReceipt(String transactionId, String operationType,
+                                  @Nullable String sourceFinId,
+                                  @Nullable String destinationFinId,
+                                  String quantity) {
+            this.transactionId = transactionId;
+            this.operationType = operationType;
+            this.sourceFinId = sourceFinId;
+            this.destinationFinId = destinationFinId;
+            this.quantity = quantity;
         }
     }
 

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
@@ -1,0 +1,269 @@
+package io.ownera.ledger.adapter.service.plan;
+
+import io.ownera.finp2p.OperationalSDK;
+import io.ownera.finp2p.opapi.model.Execution;
+import io.ownera.finp2p.opapi.model.ExecutionInstruction;
+import io.ownera.finp2p.opapi.model.ExecutionPlan;
+import io.ownera.finp2p.opapi.model.ExecutionPlanOperation;
+import io.ownera.finp2p.opapi.model.FinIdAccount1;
+import io.ownera.finp2p.opapi.model.Finp2pAsset;
+import io.ownera.finp2p.opapi.model.Finp2pAssetAccount;
+import io.ownera.finp2p.opapi.model.InstructionCompletionError;
+import io.ownera.finp2p.opapi.model.InstructionCompletionEvent;
+import io.ownera.finp2p.opapi.model.InstructionCompletionEventOutput;
+import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
+import io.ownera.finp2p.opapi.model.ReceiptOutput;
+import io.ownera.finp2p.opapi.model.TransferInstruction;
+import io.ownera.ledger.adapter.service.model.PlanApprovalStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Two reports from the field, addressed together:
+ *
+ * <ol>
+ *   <li>{@code ctx.planId} sometimes carried what looked like a nonce rather than the canonical
+ *       plan id the adapter could feed into {@code getReceipt} / metadata lookups. The skeleton
+ *       now prefers {@code execution.getPlan().getId()} (the fetched plan's own id) over the
+ *       wire {@code executionPlan.id}, so the hook always sees the router-canonical handle.</li>
+ *   <li>The hook context's {@code result} field was always {@code null} — adapters had to do a
+ *       separate {@code getReceipt} round-trip to get the transaction id of the completed
+ *       instruction. We now extract the matching entry from
+ *       {@code execution.instructionsCompletionEvents}, surface it as {@code ctx.result} and
+ *       attach the richer {@code ctx.receipt} (transaction id, operation type, source /
+ *       destination fin-ids, quantity).</li>
+ * </ol>
+ */
+class InboundTransferReceiptTest {
+
+    private OperationalSDK sdk;
+
+    @BeforeEach
+    void setup() {
+        sdk = Mockito.mock(OperationalSDK.class);
+    }
+
+    @Test
+    void hookContextCarriesCanonicalPlanIdFromFetchedExecution() throws Exception {
+        // The router posts /api/plan/proposal with `executionPlan.id` = wireId. We fetch the
+        // plan via getExecutionPlan(wireId); the response's plan.id is what the router
+        // considers canonical. The hook must see the canonical id, not the wire-envelope id.
+        String wireId = "af2eaceb1b31376a05aaa3934404122ea732a30d00000000000000006a15d88c";
+        String canonicalId = "plan-canonical-" + System.nanoTime();
+
+        Execution exec = executionWithTransfer(canonicalId, 7, "org-test", null);
+        Mockito.when(sdk.getExecutionPlan(wireId)).thenReturn(exec);
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        InboundTransferHook hook = capture(seen);
+
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, hook);
+
+        PlanApprovalStatus status = svc.proposeInstructionApproval("ik-" + System.nanoTime(), wireId, 7);
+        assertTrue(status.getClass().getSimpleName().equals("ApprovedPlan"));
+        assertNotNull(seen.get(), "hook must fire on transfer instruction");
+        assertEquals(canonicalId, seen.get().planId,
+                "hook context must carry execution.plan.id, not the wire envelope id");
+    }
+
+    @Test
+    void hookContextFallsBackToWireIdWhenPlanIdIsAbsent() throws Exception {
+        // Defensive: if the fetched plan has a null/empty id, we must not surface a null planId
+        // — fall back to the wire id so the hook still has *some* handle to log/cross-reference.
+        String wireId = "wire-fallback-" + System.nanoTime();
+        Execution exec = executionWithTransfer(null, 7, "org-test", null);
+        Mockito.when(sdk.getExecutionPlan(wireId)).thenReturn(exec);
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, capture(seen));
+
+        svc.proposeInstructionApproval("ik", wireId, 7);
+        assertNotNull(seen.get());
+        assertEquals(wireId, seen.get().planId);
+    }
+
+    @Test
+    void hookReceivesReceiptDetailsWhenCompletionEventIsAvailable() throws Exception {
+        // The router has reported a ReceiptOutput for instruction 7. The hook must see both
+        // the lightweight `result.transactionId` summary and the richer `receipt` payload
+        // (operation type, source/destination fin-ids, quantity).
+        String planId = "plan-with-receipt-" + System.nanoTime();
+        ReceiptOutput receipt = new ReceiptOutput();
+        receipt.setId("tx-" + System.nanoTime());
+        receipt.setOperationType(ReceiptOutput.OperationTypeEnum.ISSUE);
+        receipt.setQuantity("42");
+        Finp2pAssetAccount source = finp2pAccount("src-fin-id");
+        Finp2pAssetAccount destination = finp2pAccount("dst-fin-id");
+        receipt.setSource(source);
+        receipt.setDestination(destination);
+
+        Execution exec = executionWithTransfer(planId, 7, "org-test", receipt);
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(exec);
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, capture(seen));
+
+        svc.proposeInstructionApproval("ik", planId, 7);
+
+        InboundTransferHook.InboundTransferContext ctx = seen.get();
+        assertNotNull(ctx);
+        assertNotNull(ctx.result, "lightweight result summary must be populated when a completion event lands");
+        assertEquals(InboundTransferHook.InstructionResult.Type.RECEIPT, ctx.result.type);
+        assertEquals(receipt.getId(), ctx.result.transactionId);
+
+        assertNotNull(ctx.receipt, "full InstructionReceipt must be attached when ReceiptOutput is available");
+        assertEquals(receipt.getId(), ctx.receipt.transactionId);
+        assertEquals("issue", ctx.receipt.operationType);
+        assertEquals("42", ctx.receipt.quantity);
+        assertEquals("src-fin-id", ctx.receipt.sourceFinId);
+        assertEquals("dst-fin-id", ctx.receipt.destinationFinId);
+    }
+
+    @Test
+    void hookReceivesNullReceiptWhenNoCompletionEventForInstruction() throws Exception {
+        // Proposal arrived ahead of the completion event landing on the router's
+        // instructionsCompletionEvents — the hook must still fire (the adapter may want to
+        // observe the planned transfer), but with null result / receipt.
+        String planId = "plan-no-event-" + System.nanoTime();
+        Execution exec = executionWithTransfer(planId, 7, "org-test", null);
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(exec);
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, capture(seen));
+
+        svc.proposeInstructionApproval("ik", planId, 7);
+        InboundTransferHook.InboundTransferContext ctx = seen.get();
+        assertNotNull(ctx);
+        assertNull(ctx.result);
+        assertNull(ctx.receipt);
+    }
+
+    @Test
+    void hookReceivesErrorResultWhenCompletionEventIsAnError() throws Exception {
+        // The router reported InstructionCompletionError instead of a ReceiptOutput. The hook
+        // must see the error in `result` (so it knows the instruction failed) and `receipt`
+        // must be null (no router-side receipt exists).
+        String planId = "plan-with-error-" + System.nanoTime();
+
+        InstructionCompletionError error = new InstructionCompletionError();
+        error.setCode(409);
+        error.setMessage("on-chain rejection");
+
+        Execution exec = executionWithTransferErrorEvent(planId, 7, "org-test", error);
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(exec);
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, capture(seen));
+
+        svc.proposeInstructionApproval("ik", planId, 7);
+        InboundTransferHook.InboundTransferContext ctx = seen.get();
+        assertNotNull(ctx);
+        assertNotNull(ctx.result);
+        assertEquals(InboundTransferHook.InstructionResult.Type.ERROR, ctx.result.type);
+        assertEquals(409, ctx.result.code);
+        assertEquals("on-chain rejection", ctx.result.message);
+        assertNull(ctx.receipt, "error completion produces no receipt to surface");
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private static InboundTransferHook capture(AtomicReference<InboundTransferHook.InboundTransferContext> sink) {
+        return new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) {}
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) { sink.set(ctx); }
+        };
+    }
+
+    private static Finp2pAssetAccount finp2pAccount(String finId) {
+        FinIdAccount1 fin = new FinIdAccount1();
+        fin.setFinId(finId);
+        Finp2pAsset asset = new Finp2pAsset();
+        asset.setId("asset-receipt-side");
+        Finp2pAssetAccount acct = new Finp2pAssetAccount();
+        acct.setAccount(fin);
+        acct.setAsset(asset);
+        return acct;
+    }
+
+    /**
+     * Build an Execution with one TransferInstruction at {@code sequence} and (optionally) a
+     * matching completion event carrying {@code receipt} on the ReceiptOutput branch.
+     */
+    private static Execution executionWithTransfer(String planId, int sequence, String orgId, ReceiptOutput receipt) {
+        TransferInstruction transfer = new TransferInstruction();
+        transfer.setSource(ledgerAccount("src-fin"));
+        transfer.setDestination(ledgerAccount("dst-fin"));
+        transfer.setAmount("100");
+
+        ExecutionPlanOperation op = new ExecutionPlanOperation();
+        op.setActualInstance(transfer);
+
+        ExecutionInstruction instr = new ExecutionInstruction();
+        instr.setSequence(sequence);
+        instr.setOrganizations(Collections.singletonList(orgId));
+        instr.setExecutionPlanOperation(op);
+
+        ExecutionPlan plan = new ExecutionPlan();
+        plan.setId(planId);
+        plan.setInstructions(Collections.singletonList(instr));
+
+        Execution exec = new Execution();
+        exec.setPlan(plan);
+
+        if (receipt != null) {
+            InstructionCompletionEventOutput output = new InstructionCompletionEventOutput();
+            output.setActualInstance(receipt);
+            InstructionCompletionEvent event = new InstructionCompletionEvent();
+            event.setInstructionSequenceNumber(sequence);
+            event.setOutput(output);
+            List<InstructionCompletionEvent> events = new ArrayList<>();
+            events.add(event);
+            exec.setInstructionsCompletionEvents(events);
+        }
+        return exec;
+    }
+
+    private static Execution executionWithTransferErrorEvent(String planId, int sequence, String orgId, InstructionCompletionError error) {
+        Execution exec = executionWithTransfer(planId, sequence, orgId, null);
+
+        InstructionCompletionEventOutput output = new InstructionCompletionEventOutput();
+        output.setActualInstance(error);
+        InstructionCompletionEvent event = new InstructionCompletionEvent();
+        event.setInstructionSequenceNumber(sequence);
+        event.setOutput(output);
+
+        List<InstructionCompletionEvent> events = new ArrayList<>();
+        events.add(event);
+        exec.setInstructionsCompletionEvents(events);
+        return exec;
+    }
+
+    private static LedgerAccountAsset ledgerAccount(String finId) {
+        FinIdAccount1 fin = new FinIdAccount1();
+        fin.setFinId(finId);
+        Finp2pAsset asset = new Finp2pAsset();
+        asset.setId("asset-test");
+        Finp2pAssetAccount acct = new Finp2pAssetAccount();
+        acct.setAccount(fin);
+        acct.setAsset(asset);
+        LedgerAccountAsset lea = new LedgerAccountAsset();
+        lea.setFinp2pAccount(acct);
+        return lea;
+    }
+}


### PR DESCRIPTION
## Summary

Two reports from the field:

### 1. `ctx.planId` sometimes looked like a nonce

What hedera/swift were seeing in their hook logs:

```
plan=af2eaceb1b31376a05aaa3934404122ea732a30d00000000000000006a15d88c sequence=7
```

That's the wire envelope's `executionPlan.id` from the proposal request — which can diverge from the plan's own id once the router post-processes the proposal. The skeleton now **prefers `execution.getPlan().getId()`** (the fetched plan's own id) and falls back to the wire id only when `plan.getId()` is null/empty. The hook now sees the canonical router handle suitable for downstream `getReceipt` / metadata lookups.

### 2. `ctx.result` was always null

Adapters had to do a separate `getReceipt` round-trip to learn the instruction's transaction id. We now look up the matching entry in `execution.instructionsCompletionEvents` and populate:

- **`ctx.result`** — the existing lightweight `RECEIPT` / `ERROR` summary (was always null before).
- **`ctx.receipt`** — a new `InstructionReceipt` with `transactionId`, `operationType` (issue/transfer/redeem/release/hold), source/destination fin-ids, quantity.

Both stay `null` when no completion event has landed yet — the proposal arriving ahead of the on-chain completion is the common race. Adapters should treat null as "not ready" rather than "no receipt".

## Back-compat

`InboundTransferContext` gets a new constructor overload that accepts the `receipt`; the old 7-arg constructor delegates with `receipt = null` so existing adapter call sites continue to compile.

## Test plan
- [x] 5 new tests in `InboundTransferReceiptTest` cover: canonical planId, wire-fallback, receipt populated from `ReceiptOutput`, null result/receipt when no event, error-typed result from `InstructionCompletionError`.
- [x] Existing `InboundTransferRejectionTest` continues to pass unchanged (verifies the back-compat constructor).
- [x] `mvn clean test` — full reactor green (196 tests, 0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)