### PR TITLE
InboundTransferHook: gate by destination-asset org + handle release

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
@@ -16,6 +16,7 @@ import io.ownera.finp2p.opapi.model.IssueInstruction;
 import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
 import io.ownera.finp2p.opapi.model.ReceiptOutput;
 import io.ownera.finp2p.opapi.model.RedemptionInstruction;
+import io.ownera.finp2p.opapi.model.ReleaseInstruction;
 import io.ownera.finp2p.opapi.model.TransferInstruction;
 import io.ownera.ledger.adapter.service.PlanApprovalService;
 import io.ownera.ledger.adapter.service.model.*;
@@ -164,31 +165,47 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
                 if (op == null) continue;
                 Object actual = op.getActualInstance();
 
+                // The inbound hook fires for both transfer and release — each moves value to a
+                // destination account, and the adapter on the receiving side credits locally.
+                LedgerAccountAsset source = null;
+                LedgerAccountAsset destination = null;
+                String amount = null;
                 if (actual instanceof TransferInstruction) {
                     TransferInstruction transfer = (TransferInstruction) actual;
-                    String destFinId = finIdOf(transfer.getDestination());
-                    String srcFinId = finIdOf(transfer.getSource());
-                    Asset asset = toInternalAsset(transfer.getDestination() != null
-                            ? transfer.getDestination()
-                            : transfer.getSource());
+                    source = transfer.getSource();
+                    destination = transfer.getDestination();
+                    amount = transfer.getAmount();
+                } else if (actual instanceof ReleaseInstruction) {
+                    ReleaseInstruction release = (ReleaseInstruction) actual;
+                    source = release.getSource();
+                    destination = release.getDestination();
+                    amount = release.getAmount();
+                }
 
-                    InstructionCompletionEvent event = findCompletionEvent(execution, instructionSequence);
-                    InboundTransferHook.InstructionResult result = toInstructionResult(event);
-                    InboundTransferHook.InstructionReceipt receipt = toInstructionReceipt(event);
+                // Gate on the destination asset's org: fire only when *we* are the receiving
+                // side. `instr.getOrganizations()` is the executing (sender) org and must not
+                // be used here — it would fire the inbound hook on the wrong adapter.
+                if (destination != null) {
+                    Asset destAsset = toInternalAsset(destination);
+                    if (orgId.equals(orgIdFromResource(destAsset.assetId))) {
+                        InstructionCompletionEvent event = findCompletionEvent(execution, instructionSequence);
+                        InboundTransferHook.InstructionResult result = toInstructionResult(event);
+                        InboundTransferHook.InstructionReceipt receipt = toInstructionReceipt(event);
 
-                    try {
-                        inboundTransferHook.onInboundTransfer(idempotencyKey,
-                                new InboundTransferHook.InboundTransferContext(
-                                        canonicalPlanId, srcFinId,
-                                        asset,
-                                        destFinId, transfer.getAmount(),
-                                        instructionSequence, result, receipt));
-                    } catch (InboundTransferRejection r) {
-                        logger.info("Inbound transfer rejected by hook: plan={}, seq={}, code={}, msg={}",
-                                canonicalPlanId, instructionSequence, r.getCode(), r.getMessage());
-                        return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
-                    } catch (Exception e) {
-                        logger.warn("Inbound transfer hook failed: {}", e.getMessage());
+                        try {
+                            inboundTransferHook.onInboundTransfer(idempotencyKey,
+                                    new InboundTransferHook.InboundTransferContext(
+                                            canonicalPlanId, finIdOf(source),
+                                            destAsset,
+                                            finIdOf(destination), amount,
+                                            instructionSequence, result, receipt));
+                        } catch (InboundTransferRejection r) {
+                            logger.info("Inbound transfer rejected by hook: plan={}, seq={}, code={}, msg={}",
+                                    canonicalPlanId, instructionSequence, r.getCode(), r.getMessage());
+                            return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
+                        } catch (Exception e) {
+                            logger.warn("Inbound transfer hook failed: {}", e.getMessage());
+                        }
                     }
                 }
                 break;
@@ -313,30 +330,25 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
 
         } else if (instruction instanceof TransferInstruction) {
             TransferInstruction transfer = (TransferInstruction) instruction;
+
+            PlanApprovalStatus rejection = firePlannedInboundHook(idempotencyKey, planId,
+                    transfer.getSource(), transfer.getDestination(), transfer.getAmount());
+            if (rejection != null) return rejection;
+
             FinIdAccount source = toFinIdAccount(transfer.getSource());
             DestinationAccount dest = toDestinationAccount(transfer.getDestination());
             Asset asset = toInternalAsset(transfer.getSource() != null ? transfer.getSource() : transfer.getDestination());
-
-            // Notify inbound transfer hook if destination is our org
-            if (inboundTransferHook != null && transfer.getDestination() != null) {
-                try {
-                    inboundTransferHook.onPlannedInboundTransfer(idempotencyKey,
-                            new InboundTransferHook.PlannedInboundTransferContext(
-                                    planId,
-                                    source.finId,
-                                    asset,
-                                    finIdOf(transfer.getDestination()),
-                                    transfer.getAmount()));
-                } catch (InboundTransferRejection r) {
-                    logger.info("Planned inbound transfer rejected by hook: plan={}, code={}, msg={}",
-                            planId, r.getCode(), r.getMessage());
-                    return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
-                } catch (Exception e) {
-                    logger.warn("Planned inbound transfer hook failed: {}", e.getMessage());
-                }
-            }
-
             return validateTransfer(organizations, source, dest, asset, transfer.getAmount());
+
+        } else if (instruction instanceof ReleaseInstruction) {
+            // A release moves a held position to the destination account — same inbound
+            // semantics as transfer: the destination-side adapter credits locally. Release
+            // isn't separately plugin-validated (matches Node), so only the hook fires.
+            ReleaseInstruction release = (ReleaseInstruction) instruction;
+            PlanApprovalStatus rejection = firePlannedInboundHook(idempotencyKey, planId,
+                    release.getSource(), release.getDestination(), release.getAmount());
+            if (rejection != null) return rejection;
+            return new ApprovedPlan();
 
         } else if (instruction instanceof HoldInstruction) {
             HoldInstruction hold = (HoldInstruction) instruction;
@@ -355,8 +367,55 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
                     redeem.getAmount());
         }
 
-        // AwaitInstruction, ReleaseInstruction, RevertHoldInstruction — auto-approve
+        // AwaitInstruction, RevertHoldInstruction — auto-approve
         return new ApprovedPlan();
+    }
+
+    /**
+     * Fire {@link InboundTransferHook#onPlannedInboundTransfer} during plan approval, but only
+     * when <em>we</em> own the destination asset (i.e. we're the receiving side). The gate is
+     * the destination asset's org prefix — NOT the instruction's {@code organizations} list,
+     * which carries the executing/sending org and would fire the inbound hook on the wrong
+     * adapter.
+     *
+     * @return a {@link RejectedPlan} if the hook threw {@link InboundTransferRejection};
+     *         {@code null} to continue (hook not fired, fired cleanly, or non-typed failure).
+     */
+    private @Nullable PlanApprovalStatus firePlannedInboundHook(String idempotencyKey, String planId,
+                                                                @Nullable LedgerAccountAsset source,
+                                                                @Nullable LedgerAccountAsset destination,
+                                                                String amount) {
+        if (inboundTransferHook == null || destination == null) return null;
+        Asset destAsset = toInternalAsset(destination);
+        if (!orgId.equals(orgIdFromResource(destAsset.assetId))) return null;
+        try {
+            inboundTransferHook.onPlannedInboundTransfer(idempotencyKey,
+                    new InboundTransferHook.PlannedInboundTransferContext(
+                            planId,
+                            finIdOf(source),
+                            destAsset,
+                            finIdOf(destination),
+                            amount));
+            return null;
+        } catch (InboundTransferRejection r) {
+            logger.info("Planned inbound transfer rejected by hook: plan={}, code={}, msg={}",
+                    planId, r.getCode(), r.getMessage());
+            return new RejectedPlan(new ErrorDetails(r.getCode(), r.getMessage()));
+        } catch (Exception e) {
+            logger.warn("Planned inbound transfer hook failed: {}", e.getMessage());
+            return null;
+        }
+    }
+
+    /**
+     * Extract the org prefix from a FinP2P resource id of the shape {@code <orgId>:<type>:<rawId>}
+     * (e.g. {@code org-b:102:a640edb1-...} → {@code org-b}). Returns {@code null} if the id is
+     * null or carries no {@code :} separator.
+     */
+    static @Nullable String orgIdFromResource(@Nullable String resourceId) {
+        if (resourceId == null) return null;
+        int i = resourceId.indexOf(':');
+        return i > 0 ? resourceId.substring(0, i) : null;
     }
 
     private PlanApprovalStatus validateIssuance(List<String> organizations,

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferOrgGateTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferOrgGateTest.java
@@ -1,0 +1,199 @@
+package io.ownera.ledger.adapter.service.plan;
+
+import io.ownera.finp2p.OperationalSDK;
+import io.ownera.finp2p.opapi.model.Execution;
+import io.ownera.finp2p.opapi.model.ExecutionInstruction;
+import io.ownera.finp2p.opapi.model.ExecutionPlan;
+import io.ownera.finp2p.opapi.model.ExecutionPlanOperation;
+import io.ownera.finp2p.opapi.model.FinIdAccount1;
+import io.ownera.finp2p.opapi.model.Finp2pAsset;
+import io.ownera.finp2p.opapi.model.Finp2pAssetAccount;
+import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
+import io.ownera.finp2p.opapi.model.ReleaseInstruction;
+import io.ownera.finp2p.opapi.model.TransferInstruction;
+import io.ownera.ledger.adapter.service.model.ApprovedPlan;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * The inbound-transfer hook must fire on the <em>receiving</em> side — the org that owns the
+ * destination asset — not on the executing/sending org. Earlier the gate used the
+ * instruction's {@code organizations} list (the sender) and so fired the inbound hook on the
+ * wrong adapter. These tests pin the corrected gate: {@code orgIdFromResource(destAsset)} ==
+ * our org, for both the approval path ({@code onPlannedInboundTransfer}) and the
+ * instruction-proposal path ({@code onInboundTransfer}), across both {@code transfer} and
+ * {@code release} operations.
+ */
+class InboundTransferOrgGateTest {
+
+    private OperationalSDK sdk;
+
+    @BeforeEach
+    void setup() {
+        sdk = Mockito.mock(OperationalSDK.class);
+    }
+
+    // ── Path B: proposeInstructionApproval ──────────────────────────────
+
+    @Test
+    void onInboundTransferFiresWhenWeOwnDestinationAsset() throws Exception {
+        // dest asset org == our org → hook fires.
+        String planId = "plan-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(
+                transferExecution(planId, 7, "org-other:102:src", "org-me:102:dst"));
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        svc("org-me", capture(seen)).proposeInstructionApproval("ik", planId, 7);
+
+        assertNotNull(seen.get(), "hook must fire when we own the destination asset");
+        assertEquals(planId, seen.get().planId);
+    }
+
+    @Test
+    void onInboundTransferDoesNotFireWhenAnotherOrgOwnsDestinationAsset() throws Exception {
+        // dest asset org != our org → hook must NOT fire (we're the sender, not the receiver).
+        String planId = "plan-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(
+                transferExecution(planId, 7, "org-me:102:src", "org-other:102:dst"));
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        svc("org-me", capture(seen)).proposeInstructionApproval("ik", planId, 7);
+
+        assertNull(seen.get(), "hook must not fire on the sending side");
+    }
+
+    @Test
+    void onInboundTransferFiresForReleaseToOurOrg() throws Exception {
+        // release with dest asset org == our org → hook fires (release has inbound semantics).
+        String planId = "plan-" + System.nanoTime();
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(
+                releaseExecution(planId, 8, "org-other:102:src", "org-me:102:dst"));
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        svc("org-me", capture(seen)).proposeInstructionApproval("ik", planId, 8);
+
+        assertNotNull(seen.get(), "release to our org must fire the inbound hook");
+        assertEquals("org-me:102:dst", seen.get().asset.assetId);
+    }
+
+    // ── Path A: approvePlan → validatePlan → onPlannedInboundTransfer ───
+
+    @Test
+    void onPlannedInboundTransferFiresWhenWeOwnDestinationAsset() throws Exception {
+        String planId = "plan-" + System.nanoTime();
+        // instruction assigned to our org AND dest asset is ours → planned hook fires.
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(
+                transferExecutionAssignedTo(planId, 1, "org-me", "org-other:102:src", "org-me:102:dst"));
+
+        AtomicReference<InboundTransferHook.PlannedInboundTransferContext> seen = new AtomicReference<>();
+        svc("org-me", capturePlanned(seen)).approvePlan("ik", planId);
+
+        assertNotNull(seen.get(), "planned hook must fire when we own the destination asset");
+        assertEquals("org-me:102:dst", seen.get().asset.assetId);
+    }
+
+    @Test
+    void onPlannedInboundTransferDoesNotFireWhenAnotherOrgOwnsDestinationAsset() throws Exception {
+        String planId = "plan-" + System.nanoTime();
+        // instruction assigned to our org (we execute it) but dest asset is another org →
+        // we're the sender, planned inbound hook must NOT fire.
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(
+                transferExecutionAssignedTo(planId, 1, "org-me", "org-me:102:src", "org-other:102:dst"));
+
+        AtomicReference<InboundTransferHook.PlannedInboundTransferContext> seen = new AtomicReference<>();
+        var status = svc("org-me", capturePlanned(seen)).approvePlan("ik", planId);
+
+        assertNull(seen.get(), "planned hook must not fire on the sending side");
+        assertTrue(status instanceof ApprovedPlan);
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    private DefaultPlanApprovalService svc(String orgId, InboundTransferHook hook) {
+        return new DefaultPlanApprovalService(orgId, sdk, null, hook);
+    }
+
+    private static InboundTransferHook capture(AtomicReference<InboundTransferHook.InboundTransferContext> sink) {
+        return new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) {}
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) { sink.set(ctx); }
+        };
+    }
+
+    private static InboundTransferHook capturePlanned(AtomicReference<InboundTransferHook.PlannedInboundTransferContext> sink) {
+        return new InboundTransferHook() {
+            @Override public void onPlannedInboundTransfer(String ik, PlannedInboundTransferContext ctx) { sink.set(ctx); }
+            @Override public void onInboundTransfer(String ik, InboundTransferContext ctx) {}
+        };
+    }
+
+    private static Execution transferExecution(String planId, int seq, String srcAssetId, String dstAssetId) {
+        TransferInstruction t = new TransferInstruction();
+        t.setSource(account("src-fin", srcAssetId));
+        t.setDestination(account("dst-fin", dstAssetId));
+        t.setAmount("5");
+        return wrap(planId, seq, null, opOf(t));
+    }
+
+    private static Execution releaseExecution(String planId, int seq, String srcAssetId, String dstAssetId) {
+        ReleaseInstruction r = new ReleaseInstruction();
+        r.setSource(account("src-fin", srcAssetId));
+        r.setDestination(account("dst-fin", dstAssetId));
+        r.setAmount("1");
+        return wrap(planId, seq, null, opOf(r));
+    }
+
+    private static Execution transferExecutionAssignedTo(String planId, int seq, String orgAssigned,
+                                                         String srcAssetId, String dstAssetId) {
+        TransferInstruction t = new TransferInstruction();
+        t.setSource(account("src-fin", srcAssetId));
+        t.setDestination(account("dst-fin", dstAssetId));
+        t.setAmount("5");
+        return wrap(planId, seq, orgAssigned, opOf(t));
+    }
+
+    private static ExecutionPlanOperation opOf(Object instruction) {
+        ExecutionPlanOperation op = new ExecutionPlanOperation();
+        op.setActualInstance(instruction);
+        return op;
+    }
+
+    private static Execution wrap(String planId, int seq, String orgAssigned, ExecutionPlanOperation op) {
+        ExecutionInstruction instr = new ExecutionInstruction();
+        instr.setSequence(seq);
+        if (orgAssigned != null) {
+            instr.setOrganizations(Collections.singletonList(orgAssigned));
+        }
+        instr.setExecutionPlanOperation(op);
+
+        ExecutionPlan plan = new ExecutionPlan();
+        plan.setId(planId);
+        plan.setInstructions(Collections.singletonList(instr));
+
+        Execution exec = new Execution();
+        exec.setPlan(plan);
+        return exec;
+    }
+
+    private static LedgerAccountAsset account(String finId, String assetId) {
+        FinIdAccount1 fin = new FinIdAccount1();
+        fin.setFinId(finId);
+        Finp2pAsset asset = new Finp2pAsset();
+        asset.setId(assetId);
+        Finp2pAssetAccount acct = new Finp2pAssetAccount();
+        acct.setAccount(fin);
+        acct.setAsset(asset);
+        LedgerAccountAsset lea = new LedgerAccountAsset();
+        lea.setFinp2pAccount(acct);
+        return lea;
+    }
+}

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
@@ -207,8 +207,9 @@ class InboundTransferReceiptTest {
      */
     private static Execution executionWithTransfer(String planId, int sequence, String orgId, ReceiptOutput receipt) {
         TransferInstruction transfer = new TransferInstruction();
-        transfer.setSource(ledgerAccount("src-fin"));
-        transfer.setDestination(ledgerAccount("dst-fin"));
+        transfer.setSource(ledgerAccount("src-fin", "org-other:102:asset-src"));
+        // Destination asset carries the org prefix so the inbound hook's dest-asset-org gate fires.
+        transfer.setDestination(ledgerAccount("dst-fin", orgId + ":102:asset-dst"));
         transfer.setAmount("100");
 
         ExecutionPlanOperation op = new ExecutionPlanOperation();
@@ -255,10 +256,14 @@ class InboundTransferReceiptTest {
     }
 
     private static LedgerAccountAsset ledgerAccount(String finId) {
+        return ledgerAccount(finId, "asset-test");
+    }
+
+    private static LedgerAccountAsset ledgerAccount(String finId, String assetId) {
         FinIdAccount1 fin = new FinIdAccount1();
         fin.setFinId(finId);
         Finp2pAsset asset = new Finp2pAsset();
-        asset.setId("asset-test");
+        asset.setId(assetId);
         Finp2pAssetAccount acct = new Finp2pAssetAccount();
         acct.setAccount(fin);
         acct.setAsset(asset);

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferRejectionTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferRejectionTest.java
@@ -132,15 +132,19 @@ class InboundTransferRejectionTest {
         FinIdAccount1 dstFin = new FinIdAccount1();
         dstFin.setFinId("dst-fin-id");
 
-        Finp2pAsset asset = new Finp2pAsset();
-        asset.setId("asset-1");
+        // Destination asset must carry the org prefix matching orgId so the inbound hook's
+        // destination-asset-org gate fires (the hook only triggers when we own the dest asset).
+        Finp2pAsset destAsset = new Finp2pAsset();
+        destAsset.setId(orgId + ":102:asset-1");
+        Finp2pAsset srcAsset = new Finp2pAsset();
+        srcAsset.setId("org-other:102:asset-src");
 
         Finp2pAssetAccount srcAcct = new Finp2pAssetAccount();
         srcAcct.setAccount(srcFin);
-        srcAcct.setAsset(asset);
+        srcAcct.setAsset(srcAsset);
         Finp2pAssetAccount dstAcct = new Finp2pAssetAccount();
         dstAcct.setAccount(dstFin);
-        dstAcct.setAsset(asset);
+        dstAcct.setAsset(destAsset);
 
         LedgerAccountAsset src = new LedgerAccountAsset();
         src.setFinp2pAccount(srcAcct);


### PR DESCRIPTION
## Summary

The inbound-transfer hook was gated on the wrong org. It must fire on the **receiving** side — the org that owns the destination asset — but:

- **`onPlannedInboundTransfer`** (approval path) fired for any `TransferInstruction` assigned to our org via `instr.getOrganizations()`. That's the executing/**sending** org → the hook fired on the wrong adapter. The `// Notify inbound transfer hook if destination is our org` comment was aspirational; there was no such check.
- **`onInboundTransfer`** (instruction-proposal path) had **no org gate at all** → fired on every org that saw the proposal.

Both now gate on `orgIdFromResource(destinationAsset.assetId).equals(orgId)`, parsed from the `org-b:102:…` resource prefix — matching Node's `orgIdFromResource(destinationAsset.assetId) === this.orgId`. The instruction's `organizations` list is no longer used for the hook decision.

Also: **handle `ReleaseInstruction`** on both paths, not just `TransferInstruction` — a release moves a held position to the destination account, same inbound semantics. Release isn't separately plugin-validated (matches Node).

New `orgIdFromResource` + `firePlannedInboundHook` helpers shared between the transfer and release branches.

## Behaviour change

Adapters will start seeing the hook on the **destination** side and stop seeing it on the **sender** side. For SWIFT's loan plan (`org-c → org-b` transfer at seq 7), the hook now fires on org-b (destination asset `org-b:102:…`), not org-c.

## Test plan
- [x] `InboundTransferOrgGateTest` (5 new): hook fires iff we own the destination asset, for transfer + release, on both paths; does **not** fire on the sending side.
- [x] `InboundTransferRejectionTest` / `InboundTransferReceiptTest` updated so destination assets carry the org prefix the gate now requires; all still pass.
- [x] `mvn clean test` — full reactor green (201 tests, +5).

## Remaining intentional divergence from Node
Java still fires `onInboundTransfer` even when no completion event has landed (null `result`/`receipt`); Node skips until the event arrives. Left as-is per the 0.28.21 decision — adapters treat null as "not ready".

🤖 Generated with [Claude Code](https://claude.com/claude-code)