### PR TITLE
InstructionReceipt: add operationId from transactionDetails

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
@@ -271,10 +271,15 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
         String operationType = receipt.getOperationType() != null
                 ? receipt.getOperationType().getValue()
                 : null;
+        String operationId = receipt.getDetails() != null
+                && receipt.getDetails().getTransactionDetails() != null
+                ? receipt.getDetails().getTransactionDetails().getOperationId()
+                : null;
         String sourceFinId = finIdOf(receipt.getSource());
         String destinationFinId = finIdOf(receipt.getDestination());
         return new InboundTransferHook.InstructionReceipt(
                 receipt.getId(),
+                operationId,
                 operationType,
                 sourceFinId,
                 destinationFinId,

--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferHook.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/InboundTransferHook.java
@@ -86,17 +86,25 @@ public interface InboundTransferHook {
     class InstructionReceipt {
         /** Router-side receipt id (== local {@code transactionId}). */
         public final String transactionId;
+        /**
+         * Router-side operation id from {@code transactionDetails.operationId} — the handle
+         * the router uses to correlate an instruction's receipt back to its operation
+         * (e.g. {@code org-c:106:<planRawId>_<seq>} for on-chain ops, or the nonce for
+         * vanilla/db ops). May be {@code null} if the router didn't populate it.
+         */
+        public final @Nullable String operationId;
         /** Operation type as reported by the router (e.g. {@code "issue"}, {@code "transfer"}). */
         public final String operationType;
         public final @Nullable String sourceFinId;
         public final @Nullable String destinationFinId;
         public final String quantity;
 
-        public InstructionReceipt(String transactionId, String operationType,
+        public InstructionReceipt(String transactionId, @Nullable String operationId, String operationType,
                                   @Nullable String sourceFinId,
                                   @Nullable String destinationFinId,
                                   String quantity) {
             this.transactionId = transactionId;
+            this.operationId = operationId;
             this.operationType = operationType;
             this.sourceFinId = sourceFinId;
             this.destinationFinId = destinationFinId;

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
@@ -12,7 +12,9 @@ import io.ownera.finp2p.opapi.model.InstructionCompletionError;
 import io.ownera.finp2p.opapi.model.InstructionCompletionEvent;
 import io.ownera.finp2p.opapi.model.InstructionCompletionEventOutput;
 import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
+import io.ownera.finp2p.opapi.model.ReceiptAssetDetails;
 import io.ownera.finp2p.opapi.model.ReceiptOutput;
+import io.ownera.finp2p.opapi.model.ReceiptTransactionDetails;
 import io.ownera.finp2p.opapi.model.TransferInstruction;
 import io.ownera.ledger.adapter.service.model.PlanApprovalStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -109,6 +111,12 @@ class InboundTransferReceiptTest {
         Finp2pAssetAccount destination = finp2pAccount("dst-fin-id");
         receipt.setSource(source);
         receipt.setDestination(destination);
+        ReceiptTransactionDetails txDetails = new ReceiptTransactionDetails();
+        txDetails.setOperationId("org-test:106:plan-raw_7");
+        txDetails.setTransactionId(receipt.getId());
+        ReceiptAssetDetails details = new ReceiptAssetDetails();
+        details.setTransactionDetails(txDetails);
+        receipt.setDetails(details);
 
         Execution exec = executionWithTransfer(planId, 7, "org-test", receipt);
         Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(exec);
@@ -127,6 +135,8 @@ class InboundTransferReceiptTest {
 
         assertNotNull(ctx.receipt, "full InstructionReceipt must be attached when ReceiptOutput is available");
         assertEquals(receipt.getId(), ctx.receipt.transactionId);
+        assertEquals("org-test:106:plan-raw_7", ctx.receipt.operationId,
+                "operationId must be taken from details.transactionDetails.operationId");
         assertEquals("issue", ctx.receipt.operationType);
         assertEquals("42", ctx.receipt.quantity);
         assertEquals("src-fin-id", ctx.receipt.sourceFinId);


### PR DESCRIPTION
## Summary

`InstructionReceipt` (on `InboundTransferHook`) carried `transactionId` but not the router's `operationId`. The operationId is the handle the router uses to correlate an instruction's receipt back to its operation — `org-c:106:<planRawId>_<seq>` for on-chain ops, or the nonce for vanilla/db ops — so adapters reconciling against the router want it.

Adds a nullable `operationId` field, sourced from `ReceiptOutput.getDetails().getTransactionDetails().getOperationId()` with null-guards at each hop.

## Compatibility

`InstructionReceipt` is constructed only by the framework (in `toInstructionReceipt`); adapters read it. The constructor gains one param — no adapter call sites affected.

## Test plan
- [x] `InboundTransferReceiptTest` extended: fixture sets `details.transactionDetails.operationId`, test asserts it surfaces on `ctx.receipt.operationId`.
- [x] `mvn clean test` — full reactor green (201 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)