### PR TITLE
Take instruction transactionId from transactionDetails, not output id

### DIFF
--- a/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
+++ b/skeleton/src/main/java/io/ownera/ledger/adapter/service/plan/DefaultPlanApprovalService.java
@@ -15,6 +15,7 @@ import io.ownera.finp2p.opapi.model.InstructionCompletionEventOutput;
 import io.ownera.finp2p.opapi.model.IssueInstruction;
 import io.ownera.finp2p.opapi.model.LedgerAccountAsset;
 import io.ownera.finp2p.opapi.model.ReceiptOutput;
+import io.ownera.finp2p.opapi.model.ReceiptTransactionDetails;
 import io.ownera.finp2p.opapi.model.RedemptionInstruction;
 import io.ownera.finp2p.opapi.model.ReleaseInstruction;
 import io.ownera.finp2p.opapi.model.TransferInstruction;
@@ -245,7 +246,7 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
         Object actual = output.getActualInstance();
         if (actual instanceof ReceiptOutput) {
             ReceiptOutput receipt = (ReceiptOutput) actual;
-            return InboundTransferHook.InstructionResult.receipt(receipt.getId());
+            return InboundTransferHook.InstructionResult.receipt(transactionIdOf(receipt));
         }
         if (actual instanceof InstructionCompletionError) {
             InstructionCompletionError error = (InstructionCompletionError) actual;
@@ -271,19 +272,37 @@ public class DefaultPlanApprovalService implements PlanApprovalService {
         String operationType = receipt.getOperationType() != null
                 ? receipt.getOperationType().getValue()
                 : null;
-        String operationId = receipt.getDetails() != null
-                && receipt.getDetails().getTransactionDetails() != null
-                ? receipt.getDetails().getTransactionDetails().getOperationId()
+        ReceiptTransactionDetails txDetails = receipt.getDetails() != null
+                ? receipt.getDetails().getTransactionDetails()
                 : null;
+        String operationId = txDetails != null ? txDetails.getOperationId() : null;
         String sourceFinId = finIdOf(receipt.getSource());
         String destinationFinId = finIdOf(receipt.getDestination());
         return new InboundTransferHook.InstructionReceipt(
-                receipt.getId(),
+                transactionIdOf(receipt),
                 operationId,
                 operationType,
                 sourceFinId,
                 destinationFinId,
                 receipt.getQuantity());
+    }
+
+    /**
+     * The transaction id of a completed instruction is {@code details.transactionDetails.transactionId}
+     * (matches Node) — NOT the output-level {@code receipt.getId()}. For on-chain ops the two
+     * coincide (both the chain tx hash), but for vanilla/db ops {@code receipt.getId()} is the
+     * operation nonce while the real transaction id is the plan-scoped UUID in
+     * {@code transactionDetails}. Falls back to {@code receipt.getId()} only when
+     * {@code transactionDetails} (or its {@code transactionId}) is absent.
+     */
+    private static @Nullable String transactionIdOf(ReceiptOutput receipt) {
+        ReceiptTransactionDetails txDetails = receipt.getDetails() != null
+                ? receipt.getDetails().getTransactionDetails()
+                : null;
+        if (txDetails != null && txDetails.getTransactionId() != null) {
+            return txDetails.getTransactionId();
+        }
+        return receipt.getId();
     }
 
     private static @Nullable String finIdOf(@Nullable Finp2pAssetAccount account) {

--- a/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
+++ b/skeleton/src/test/java/io/ownera/ledger/adapter/service/plan/InboundTransferReceiptTest.java
@@ -104,7 +104,9 @@ class InboundTransferReceiptTest {
         // (operation type, source/destination fin-ids, quantity).
         String planId = "plan-with-receipt-" + System.nanoTime();
         ReceiptOutput receipt = new ReceiptOutput();
-        receipt.setId("tx-" + System.nanoTime());
+        // Output id is the operation nonce for vanilla ops — deliberately DISTINCT from the
+        // transactionDetails.transactionId so the test proves we read the latter, not the former.
+        receipt.setId("output-nonce-b88835f9");
         receipt.setOperationType(ReceiptOutput.OperationTypeEnum.ISSUE);
         receipt.setQuantity("42");
         Finp2pAssetAccount source = finp2pAccount("src-fin-id");
@@ -113,7 +115,7 @@ class InboundTransferReceiptTest {
         receipt.setDestination(destination);
         ReceiptTransactionDetails txDetails = new ReceiptTransactionDetails();
         txDetails.setOperationId("org-test:106:plan-raw_7");
-        txDetails.setTransactionId(receipt.getId());
+        txDetails.setTransactionId("13abf622-real-tx-id");
         ReceiptAssetDetails details = new ReceiptAssetDetails();
         details.setTransactionDetails(txDetails);
         receipt.setDetails(details);
@@ -131,16 +133,48 @@ class InboundTransferReceiptTest {
         assertNotNull(ctx);
         assertNotNull(ctx.result, "lightweight result summary must be populated when a completion event lands");
         assertEquals(InboundTransferHook.InstructionResult.Type.RECEIPT, ctx.result.type);
-        assertEquals(receipt.getId(), ctx.result.transactionId);
+        assertEquals("13abf622-real-tx-id", ctx.result.transactionId,
+                "result.transactionId must come from details.transactionDetails.transactionId, not the output id");
 
         assertNotNull(ctx.receipt, "full InstructionReceipt must be attached when ReceiptOutput is available");
-        assertEquals(receipt.getId(), ctx.receipt.transactionId);
+        assertEquals("13abf622-real-tx-id", ctx.receipt.transactionId,
+                "receipt.transactionId must come from details.transactionDetails.transactionId, not the output id");
         assertEquals("org-test:106:plan-raw_7", ctx.receipt.operationId,
                 "operationId must be taken from details.transactionDetails.operationId");
         assertEquals("issue", ctx.receipt.operationType);
         assertEquals("42", ctx.receipt.quantity);
         assertEquals("src-fin-id", ctx.receipt.sourceFinId);
         assertEquals("dst-fin-id", ctx.receipt.destinationFinId);
+    }
+
+    @Test
+    void transactionIdFallsBackToOutputIdWhenTransactionDetailsAbsent() throws Exception {
+        // Malformed / partial completion event: ReceiptOutput with no details block. We fall
+        // back to the output id so the hook still gets *some* handle rather than null.
+        String planId = "plan-no-txdetails-" + System.nanoTime();
+        ReceiptOutput receipt = new ReceiptOutput();
+        receipt.setId("output-id-only");
+        receipt.setOperationType(ReceiptOutput.OperationTypeEnum.TRANSFER);
+        receipt.setQuantity("7");
+        receipt.setSource(finp2pAccount("s"));
+        receipt.setDestination(finp2pAccount("d"));
+        // no setDetails(...) → transactionDetails absent
+
+        Execution exec = executionWithTransfer(planId, 7, "org-test", receipt);
+        Mockito.when(sdk.getExecutionPlan(planId)).thenReturn(exec);
+
+        AtomicReference<InboundTransferHook.InboundTransferContext> seen = new AtomicReference<>();
+        DefaultPlanApprovalService svc = new DefaultPlanApprovalService(
+                "org-test", sdk, null, capture(seen));
+
+        svc.proposeInstructionApproval("ik", planId, 7);
+
+        InboundTransferHook.InboundTransferContext ctx = seen.get();
+        assertNotNull(ctx);
+        assertEquals("output-id-only", ctx.receipt.transactionId,
+                "with no transactionDetails, fall back to the output id");
+        assertNull(ctx.receipt.operationId, "no transactionDetails → no operationId");
+        assertEquals("output-id-only", ctx.result.transactionId);
     }
 
     @Test


### PR DESCRIPTION
## Summary

`InstructionReceipt.transactionId` (and `InstructionResult.transactionId`) were sourced from `ReceiptOutput.getId()` — the output/receipt id. For on-chain ops that coincides with the real transaction id, but for **vanilla/db ops** `getId()` is the operation **nonce** while the actual transaction id lives in `details.transactionDetails.transactionId` (the plan-scoped UUID, e.g. `13abf622-…`). So the real transaction id was dropped and the nonce surfaced in its place.

Node takes it from `output.details.transactionDetails.transactionId` ([service.ts:31](https://github.com/owneraio/finp2p-nodejs-skeleton-adapter/blob/main/skeleton/src/services/plan/service.ts#L31)). This PR matches that:

- New `transactionIdOf(ReceiptOutput)` reads `details.transactionDetails.transactionId`, falling back to `receipt.getId()` only when `transactionDetails` (or its `transactionId`) is absent.
- Used by **both** `toInstructionResult` and `toInstructionReceipt` so the two stay consistent.

## Behaviour change

For vanilla/db instruction receipts, `ctx.receipt.transactionId` / `ctx.result.transactionId` now carry the plan-scoped transaction UUID instead of the operation nonce. (The nonce is still available as `ctx.receipt.operationId` when it's the operationId, per 0.28.23.) On-chain ops are unchanged (id == transactionId there).

## Test plan
- [x] `InboundTransferReceiptTest` updated: output id and `transactionDetails.transactionId` are now deliberately distinct, asserting we read the latter.
- [x] New fallback test: no `transactionDetails` → falls back to the output id.
- [x] `mvn clean test` — full reactor green (202 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)